### PR TITLE
added constructors to list of public methods (fixes #61)

### DIFF
--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -39,7 +39,7 @@ def main(language, pkg_name: str, data_dir: str):
 
     print(analysis_script)
 
-    cmd = '{} --pkg {} --output_dir {} --kwargs-string ~~KWARGS~~'.format(
+    cmd = '{} --pkg {} --output_dir {} --kwargs-string ~~KWARGS~~ --constructor-string ~~CONSTRUCTOR~~'.format(
         analysis_script, pkg_name, data_dir
     )
 


### PR DESCRIPTION
As of this PR, class constructors will now show up in the list of public methods! Because the constructors for classes can be different across languages, I added a `--constructor-string` argument similar to the way "pass through kwargs" differences were handled.

For example, in Python the constructor is called `__init__()` and in R6 (R) it is `initialize()`