### PR TITLE
made doppel-describe exit with non-0 code on failed runs (fixes #81, …

### DIFF
--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -2,6 +2,7 @@
 import click
 import pkg_resources
 import os
+import sys
 
 
 @click.command()
@@ -46,7 +47,11 @@ def main(language, pkg_name: str, data_dir: str):
     print("Describing package with command:\n {}".format(cmd))
 
     # Invoke the analysis script
-    os.system(cmd)
+    exit_code = os.system(cmd)
+
+    if exit_code != 0:
+        msg = "doppel-describe exited with non-zero exit code: {}"
+        raise RuntimeError(msg.format(exit_code))
 
     return
 

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -2,7 +2,6 @@
 import click
 import pkg_resources
 import os
-import sys
 
 
 @click.command()


### PR DESCRIPTION
This project is meant to be used in CI, so it's pretty important that it actually returns a non-zero exit code when things fail. This fixes a bug in capturing failed `system()` calls from `doppel-describe`.

I couldn't figure out how to pass the actual exit code all the way back through (`sys.exit(exit_code)` was returning a 0 when I ran `$?`) but I'm not gonna worry about it. Python exceptions will make the python process return with 1, which is good enough.