### PR TITLE
Addressed bugs in function argument comparisions in SimpleReporter (f…

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ coverage:
   status:
     project:
       default:
-        target: '40'
+        target: '55'
     patch:
       default:
         target: '20'

--- a/doppel/PackageCollection.py
+++ b/doppel/PackageCollection.py
@@ -10,6 +10,9 @@ class PackageCollection:
             assert isinstance(pkg, PackageAPI)
         self.pkgs = packages
 
+    def package_names(self) -> List[str]:
+        return([p.name() for p in self.pkgs])
+
     def all_classes(self) -> List[str]:
         """
         List of all classes that exist in at least

--- a/doppel/reporters.py
+++ b/doppel/reporters.py
@@ -31,10 +31,6 @@ class _OutputTable:
 
 class SimpleReporter:
 
-    errors = []
-    exists_string = 'yes'
-    absent_string = 'no'
-
     def __init__(self, pkgs: list, errors_allowed: int):
         """Default object used to manage doppel reporting
 
@@ -52,6 +48,10 @@ class SimpleReporter:
         for pkg in pkgs:
             assert isinstance(pkg, doppel.PackageAPI)
 
+        self.errors = []
+        self.exists_string = 'yes'
+        self.absent_string = 'no'
+
         self.pkgs = pkgs
         self.pkg_collection = doppel.PackageCollection(pkgs)
         self._errors_allowed = errors_allowed
@@ -67,7 +67,7 @@ class SimpleReporter:
         # Checks (these print output as they're run)
         self._check_function_count()
         self._check_function_names()
-        self._check_function_arg_names()
+        self._check_function_args()
 
         self._check_class_count()
         self._check_class_names()
@@ -176,7 +176,7 @@ class SimpleReporter:
         # Print output
         stdout.write("\n")
 
-    def _check_function_arg_names(self):
+    def _check_function_args(self):
         """
         For each function that is in both packages, check
         whether the arguments to the functions differ.

--- a/doppel/reporters.py
+++ b/doppel/reporters.py
@@ -180,14 +180,15 @@ class SimpleReporter:
         """
         For each function that is in both packages, check
         whether the arguments to the functions differ.
-
-        This method does not consider argument order.
         """
         stdout.write("\nFunction Argument Names\n")
         stdout.write("=======================\n")
 
-        func_blocks_by_package = {}
-        pkg_names = []
+        func_blocks_by_package = {
+            pkg.name(): pkg.pkg_dict['functions']
+            for pkg in self.pkgs
+        }
+        pkg_names = self.pkg_collection.package_names()
         shared_functions = self.pkg_collection.shared_functions()
         all_functions = self.pkg_collection.all_functions()
 
@@ -217,7 +218,8 @@ class SimpleReporter:
             # check 2: same set of arguments
             same_args = reduce(lambda a, b: sorted(a) == sorted(b), args)
             if not same_args:
-                error_txt = "Function '{}()' exists in all packages but with differing set of keyword arguments."
+                error_txt = "Function '{}()' exists in all packages but some arguments are not shared in all implementations."
+                error_txt = error_txt.format(func_name)
                 self.errors.append(DoppelTestError(error_txt))
                 rows.append([func_name, 'no'])
                 continue
@@ -226,6 +228,7 @@ class SimpleReporter:
             same_order = reduce(lambda a, b: a == b, args)
             if not same_order:
                 error_txt = "Function '{}()' exists in all packages but with differing order of keyword arguments."
+                error_txt = error_txt.format(func_name)
                 self.errors.append(DoppelTestError(error_txt))
                 rows.append([func_name, 'no'])
                 continue
@@ -234,7 +237,7 @@ class SimpleReporter:
             rows.append([func_name, 'yes'])
 
         # Report output
-        stdout.write('\n{} or the {} functions shared across all packages have identical signatures\n\n'.format(
+        stdout.write('\n{} of the {} functions shared across all packages have identical signatures\n\n'.format(
             len([r for r in filter(lambda x: x[1] == 'yes', rows)]),
             len(all_functions)
         ))

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -47,6 +47,13 @@ PACKAGE_SUPER_DIFFERENT = copy.deepcopy(BASE_PACKAGE)
 PACKAGE_SUPER_DIFFERENT['name'] = 'pkg2'
 PACKAGE_SUPER_DIFFERENT['functions']['playback']['args'] = ['stuff', 'things', 'bass']
 
+PACKAGE_EMPTY = {
+    "name": "empty_pkg",
+    "language": "python",
+    "functions": {},
+    "classes": {}
+}
+
 
 class TestSimpleReporter(unittest.TestCase):
 
@@ -138,3 +145,30 @@ class TestSimpleReporter(unittest.TestCase):
         self.assertTrue(
             errors[0].msg.startswith("Function 'playback()' exists in all packages but with differing number of arguments")
         )
+
+    def test_identical_functions(self):
+        """
+        SimpleReporter should not create any errors
+        if the shared function is the same in both packages.
+        """
+        reporter = SimpleReporter(
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(BASE_PACKAGE)],
+            errors_allowed=0
+        )
+        reporter._check_function_args()
+        errors = reporter.errors
+        self.assertTrue(
+            len(errors) == 0,
+        )
+
+    def test_totally_empty(self):
+        """
+        SimpleReporter should be fine if two packages
+        are totally empty.
+        """
+        reporter = SimpleReporter(
+            pkgs=[PackageAPI(PACKAGE_EMPTY), PackageAPI(PACKAGE_EMPTY)],
+            errors_allowed=0
+        )
+        reporter._check_function_args()
+        self.assertTrue(reporter.errors == [])

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -1,5 +1,4 @@
 import unittest
-import os
 import copy
 from doppel import SimpleReporter
 from doppel import PackageAPI
@@ -57,7 +56,7 @@ class TestSimpleReporter(unittest.TestCase):
             pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_NUMBER)],
             errors_allowed=100
         )
-        reporter._check_function_arg_names()
+        reporter._check_function_args()
         errors = reporter.errors
         self.assertTrue(
             len(errors) == 1,
@@ -80,7 +79,7 @@ class TestSimpleReporter(unittest.TestCase):
             pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARGS)],
             errors_allowed=100
         )
-        reporter._check_function_arg_names()
+        reporter._check_function_args()
         errors = reporter.errors
         self.assertTrue(
             len(errors) == 1,
@@ -102,7 +101,7 @@ class TestSimpleReporter(unittest.TestCase):
             pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_ORDER)],
             errors_allowed=100
         )
-        reporter._check_function_arg_names()
+        reporter._check_function_args()
         errors = reporter.errors
         self.assertTrue(
             len(errors) == 1,

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -1,0 +1,115 @@
+import unittest
+import os
+import copy
+from doppel import SimpleReporter
+from doppel import PackageAPI
+from doppel import DoppelTestError
+
+BASE_PACKAGE = {
+    "name": "pkg1",
+    "language": "python",
+    "functions": {
+        "playback": {
+            "args": [
+                "bpm",
+                "bass"
+            ]
+        },
+        "reverse": {
+            "args": [
+                "x",
+                "y",
+                "z"
+            ]
+        },
+        "split_channels": {
+            "args": [
+                "keep_list",
+                "exclude_list"
+            ]
+        }
+    },
+    "classes": {}
+}
+
+PACKAGE_WITH_DIFFERENT_ARG_NUMBER = copy.deepcopy(BASE_PACKAGE)
+PACKAGE_WITH_DIFFERENT_ARG_NUMBER['name'] = 'pkg2'
+PACKAGE_WITH_DIFFERENT_ARG_NUMBER['functions']['playback']['args'].append('other')
+
+PACKAGE_WITH_DIFFERENT_ARGS = copy.deepcopy(BASE_PACKAGE)
+PACKAGE_WITH_DIFFERENT_ARGS['name'] = 'pkg2'
+PACKAGE_WITH_DIFFERENT_ARGS['functions']['playback']['args'] = ['bass', 'beats_per_minute']
+
+PACKAGE_WITH_DIFFERENT_ARG_ORDER = copy.deepcopy(BASE_PACKAGE)
+PACKAGE_WITH_DIFFERENT_ARG_ORDER['name'] = 'pkg2'
+PACKAGE_WITH_DIFFERENT_ARG_ORDER['functions']['playback']['args'] = ['bass', 'bpm']
+
+
+class TestSimpleReporter(unittest.TestCase):
+
+    def test_function_arg_number(self):
+        """
+        SimpleReporter should catch the condition where
+        function implementations in two packages have different
+        number of keyword arguments
+        """
+        reporter = SimpleReporter(
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_NUMBER)],
+            errors_allowed=100
+        )
+        reporter._check_function_arg_names()
+        errors = reporter.errors
+        self.assertTrue(
+            len(errors) == 1,
+        )
+        self.assertTrue(
+            all([isinstance(x, DoppelTestError) for x in errors])
+        )
+        self.assertTrue(
+            errors[0].msg == "Function 'playback()' exists in all packages but with differing number of arguments (2,3)."
+        )
+
+    def test_function_args(self):
+        """
+        SimpleReporter should catch the condition where
+        function implementations in two packages have different
+        different arguments (even if they have the same number
+        of arguments)
+        """
+        reporter = SimpleReporter(
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARGS)],
+            errors_allowed=100
+        )
+        reporter._check_function_arg_names()
+        errors = reporter.errors
+        self.assertTrue(
+            len(errors) == 1,
+        )
+        self.assertTrue(
+            all([isinstance(x, DoppelTestError) for x in errors])
+        )
+        self.assertTrue(
+            errors[0].msg == "Function 'playback()' exists in all packages but some arguments are not shared in all implementations."
+        )
+
+    def test_function_arg_order(self):
+        """
+        SimpleReporter should catch errors of the form
+        'this function has the same keyword args in
+        both packages but they are in different orders'
+        """
+        reporter = SimpleReporter(
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_ORDER)],
+            errors_allowed=100
+        )
+        reporter._check_function_arg_names()
+        errors = reporter.errors
+        self.assertTrue(
+            len(errors) == 1,
+        )
+        self.assertTrue(
+            all([isinstance(x, DoppelTestError) for x in errors])
+        )
+        self.assertTrue(
+            errors[0].msg == "Function 'playback()' exists in all packages but with differing order of keyword arguments."
+        )

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -43,6 +43,10 @@ PACKAGE_WITH_DIFFERENT_ARG_ORDER = copy.deepcopy(BASE_PACKAGE)
 PACKAGE_WITH_DIFFERENT_ARG_ORDER['name'] = 'pkg2'
 PACKAGE_WITH_DIFFERENT_ARG_ORDER['functions']['playback']['args'] = ['bass', 'bpm']
 
+PACKAGE_SUPER_DIFFERENT = copy.deepcopy(BASE_PACKAGE)
+PACKAGE_SUPER_DIFFERENT['name'] = 'pkg2'
+PACKAGE_SUPER_DIFFERENT['functions']['playback']['args'] = ['stuff', 'things', 'bass']
+
 
 class TestSimpleReporter(unittest.TestCase):
 
@@ -111,4 +115,26 @@ class TestSimpleReporter(unittest.TestCase):
         )
         self.assertTrue(
             errors[0].msg == "Function 'playback()' exists in all packages but with differing order of keyword arguments."
+        )
+
+    def test_function_all_wrong(self):
+        """
+        SimpleReporter should only throw a single error
+        if one package has a function with different args, more args
+        and different order.
+        """
+        reporter = SimpleReporter(
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_SUPER_DIFFERENT)],
+            errors_allowed=100
+        )
+        reporter._check_function_args()
+        errors = reporter.errors
+        self.assertTrue(
+            len(errors) == 1,
+        )
+        self.assertTrue(
+            all([isinstance(x, DoppelTestError) for x in errors])
+        )
+        self.assertTrue(
+            errors[0].msg.startswith("Function 'playback()' exists in all packages but with differing number of arguments")
         )


### PR DESCRIPTION
This is a work in progress (not ready to merge yet).

I found tonight while working on #50 that the functionality for comparing function signatures is broken in `doppel` currently. TL;DR that method is doing a for loop over some objects which are accidentally empty, so silently it always seems fine.

Adding unit tests around this so that the fixes in this PR are true fixes, with tests to prevent regressions in the future.