### PR TITLE
Smoke tests (fixes #80)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,15 +16,18 @@
 **/*.Rdata
 
 # testing stuff
-test_data/*.json
+**/test_data/*.json
 **/.coverage
 **/htmlcov/
 **/man/
 **/.pytest_cache/
+smoke_tests/test_data/successful_*.txt
+smoke_tests/test_data/results.txt
 
 # misc files
 **/*.DS_Store
 **/*.log
+run.sh
 
 # documentation
 **/_build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,24 @@ This document contains information for maintainers and contributing developers. 
 
 ## Testing <a name="testing"></a>
 
+### Finding bugs using smoke tests <a name="smokey"></a>
+
+A set of smoke tests are available that you can use to help find bugs in `doppel-cli`.
+
+To see if `doppel-cli` works for Python and R packages it has been shown to work for in the past, run
+
+```
+./smoke_tests/run.sh
+```
+
+To try running `doppel-cli` against all R packages installed on your system (in random order), run
+
+```
+./smoke_tests/all_r_packages.sh
+```
+
+If anything breaks, [create an issue](https://github.com/jameslamb/doppel-cli/issues) that includes the logs of the run and the results of running `Rscript -e 'sessionInfo()'`.
+
 ## Documentation <a name="documentation"></a>
 
 ## Releases <a name="releases"></a>
@@ -49,3 +67,4 @@ open https://pypi.org/project/doppel-cli/
 6. [networkx: example appveyor setup for python](https://github.com/networkx/networkx/blob/master/.appveyor.yml)
 7. [simple codecov Python example](https://github.com/codecov/example-python/blob/master/.travis.yml)
 8. [pytest fixtures](https://docs.pytest.org/en/latest/fixture.html)
+9. [inspecting builtins](https://docs.python.org/3/library/inspect.html#introspecting-callables-with-the-signature-object)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## development version
 
+* Fixed bug which could cause a `ValueError` in `doppel-describe` when a Python package used CPython and had builtins that could not be inspected. This showed up in popular packages such as `pandas` and `numpy`.
+
 ## 0.2.0
 
 * `PackageCollection` will now reject lists of `packages` which have duplicated `name`s. This prevents some forms of silent failure. ([#110](https://github.com/jameslamb/doppel-cli/pull/110))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## development version
 
-* Fixed bug which could cause a `ValueError` in `doppel-describe` when a Python package used CPython and had builtins that could not be inspected. This showed up in popular packages such as `pandas` and `numpy`.
+* Fixed bug which could cause a `ValueError` in `doppel-describe` when a Python package used CPython and had builtins that could not be inspected. This showed up in popular packages such as `pandas` and `numpy`. ([#94](https://github.com/jameslamb/doppel-cli/pull/94))
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -186,3 +186,9 @@ and
 ```
 doppel-test --help
 ```
+
+## Contributing
+
+Bug reports, questions, and feature requests should be directed to [the issues page](https://github.com/jameslamb/doppel-cli/issues).
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to contribute.

--- a/smoke_tests/all_r_packages.sh
+++ b/smoke_tests/all_r_packages.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# failure is a natural part of life
+set -e
+
+OUT_DIR=${1:-$(pwd)/smoke_tests/test_data}
+
+# Set up summary file and be sure it's blank
+SUMMARY_FILE=${OUT_DIR}/successful_r_packages.txt
+echo "" > ${SUMMARY_FILE}
+
+# Function to run doppel-describe
+# [usage]
+#     run_describe ${LANGUAGE} ${OUT_DIR} ${PKG}
+run_describe () {
+    doppel-describe \
+        --language ${1} \
+        --data-dir ${2} \
+        -p ${3}
+}
+
+R_LIB=$(
+    Rscript -e "cat(.libPaths()[1])"
+)
+ALL_R_PACKAGES=$(ls ${R_LIB})
+NUM_PACKAGES=$(echo ${ALL_R_PACKAGES} | wc -w)
+
+echo "You have ${NUM_PACKAGES} R packages installed."
+
+# Randomly select packages and start working through them
+RANDOM_PACKAGES=$(
+    echo $ALL_R_PACKAGES | tr ' ' "\n" | sort --sort=random
+)
+
+for pkg in ${RANDOM_PACKAGES}; do
+
+    echo "Running doppel on package: ${pkg}"
+
+    run_describe R ${OUT_DIR} ${pkg}
+
+    echo ${pkg} >> ${SUMMARY_FILE}
+done
+
+open ${SUMMARY_FILE}

--- a/smoke_tests/python_packages
+++ b/smoke_tests/python_packages
@@ -1,0 +1,12 @@
+argparse
+attr
+cattr
+matplotlib
+networkx
+numpy
+pandas
+pytest
+scipy
+shapely
+sphinxcontrib
+uptasticsearch

--- a/smoke_tests/r_packages
+++ b/smoke_tests/r_packages
@@ -1,0 +1,8 @@
+caret
+data.table
+dplyr
+ggplot2
+jsonlite
+pkgnet
+purrr
+uptasticsearch

--- a/smoke_tests/run.sh
+++ b/smoke_tests/run.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Failure is a natural part of life
+set -e
+
+OUT_DIR=${1:-$(pwd)/smoke_tests/test_data}
+PYTHON_PACKAGES="$(cat $(pwd)/smoke_tests/python_packages)"
+R_PACKAGES="$(cat $(pwd)/smoke_tests/r_packages)"
+
+SUMMARY_FILE=${OUT_DIR}/results.txt
+echo "" > SUMMARY_FILE
+
+# Function to run doppel-describe
+# [usage]
+#     run_describe ${LANGUAGE} ${OUT_DIR} ${PKG} ${SUMMARY_FILE}
+run_describe () {
+    {
+        doppel-describe \
+            --language ${1} \
+            --data-dir ${2} \
+            -p ${3} && \
+        echo "SUCCESS: ${pkg}" >> ${4}
+    } || {
+        echo "FAILURE: ${pkg}" >> ${4}
+    }
+}
+
+mkdir -p ${OUT_DIR}
+
+echo "Test results:" > ${SUMMARY_FILE}
+
+echo "====================="
+echo "== Python packages =="
+echo "====================="
+echo ""
+for pkg in ${PYTHON_PACKAGES}; do
+    run_describe "python" ${OUT_DIR} ${pkg} ${SUMMARY_FILE}
+done
+
+echo ""
+echo "================"
+echo "== R packages =="
+echo "================"
+echo ""
+for pkg in ${R_PACKAGES}; do
+    run_describe "r" ${OUT_DIR} ${pkg} ${SUMMARY_FILE}
+done
+
+SUCCESSES=$(cat ${SUMMARY_FILE} | grep SUCCESS | wc -l)
+FAILURES=$(cat ${SUMMARY_FILE} | grep FAILURE | wc -l)
+
+echo ""
+echo "Smoke tests complete"
+echo "Successes: ${SUCCESSES}"
+echo "Failures: ${FAILURES}"
+
+open ${SUMMARY_FILE}


### PR DESCRIPTION
This PR is a work in progress and still needs some love. It tries to introduce some smoke tests that can be run by developers on their laptops to see if `doppel-cli` still works for a bunch of R and Python packages.