### PR TITLE
WIP - added ability to compare public fields on classes

### DIFF
--- a/doppel/bin/analyze.py
+++ b/doppel/bin/analyze.py
@@ -118,40 +118,45 @@ while len(modules_to_parse) > 0:
                     _log_info("'{}' is a class in this package, adding it".format(obj_name))
                     out['classes'][obj_name] = {}
                     out['classes'][obj_name]['public_methods'] = {}
+                    out['classes'][obj_name]['public_fields'] = {}
 
                     for f in dir(obj):
                         class_member = getattr(obj, f)
 
-                        is_function = isinstance(class_member, types.FunctionType)
                         is_public = not f.startswith("_")
                         is_constructor = f == '__init__'
-                        if is_function and (is_public or is_constructor):
+                        if is_public or is_constructor:
 
-                            # Deal with decorators
-                            try:
-                                method_args = _get_arg_names(
-                                    class_member,
-                                    KWARGS_STRING
-                                )
-                            except TypeError:
-                                method_args = _get_arg_names(
-                                    class_member.__wrapped__,
-                                    KWARGS_STRING
-                                )
+                            is_function = isinstance(class_member, types.FunctionType)
+                            if is_function:
+                                # Deal with decorators
+                                try:
+                                    method_args = _get_arg_names(
+                                        class_member,
+                                        KWARGS_STRING
+                                    )
+                                except TypeError:
+                                    method_args = _get_arg_names(
+                                        class_member.__wrapped__,
+                                        KWARGS_STRING
+                                    )
 
-                            # Handle Python "self" conventions
-                            method_args = [
-                                a for a in method_args if a not in SPECIAL_METHOD_ARGS
-                            ]
+                                # Handle Python "self" conventions
+                                method_args = [
+                                    a for a in method_args if a not in SPECIAL_METHOD_ARGS
+                                ]
 
-                            # If we're dealing with the class constructor, use the
-                            # passed-in replacement value
-                            if f == '__init__':
-                                f = CONSTRUCTOR_STRING
+                                # If we're dealing with the class constructor, use the
+                                # passed-in replacement value
+                                if f == '__init__':
+                                    f = CONSTRUCTOR_STRING
 
-                            out['classes'][obj_name]['public_methods'][f] = {
-                                "args": method_args
-                            }
+                                out['classes'][obj_name]['public_methods'][f] = {
+                                    "args": method_args
+                                }
+
+                            else:
+                                out['classes'][obj_name]['public_fields'][f] = {}
             next
 
         elif isinstance(obj, types.ModuleType):


### PR DESCRIPTION
This PR attempts to address #45 and #46 . It is VERY MUCH a work in progress. The idea here is to treat as a public "field" anything that is:

* attached to a class definition
* public (using language-specific conventions)
* not a function

This was super straightforward for R6 classes in R, but it's tricky in Python. Unlike with R6 classes, Python classes allow users to dynamically attach public fields (including in the constructor). One way around this is to get in the habit of always initialized [class fields](https://www.python-course.eu/python3_class_and_instance_attributes.php) in Python classes and then later overriding them with instance-specific values, but that isn't a mainstream pattern in the Python code I've seen.

Because python "instance fields" are ambiguous without literally eval-ing the `__init__()` method, I expect tests around this list of public fields to be really problematic for projects. I think the right way to implement this is to turn checks on public fields _off_ by default and enable users to opt in to it with `--check-public-fields`.

That probably belongs in the configurability milestone, so I'm going to move this PR and the corresponding issues there.