### PR TITLE
Bugfix/misc

### DIFF
--- a/doppel/bin/analyze.R
+++ b/doppel/bin/analyze.R
@@ -36,7 +36,8 @@ KWARGS_STRING <- args[["kwargs_string"]]
 CONSTRUCTOR_STRING <- args[["constructor_string"]]
 LANGUAGE <- 'r'
 R6_SPECIAL_METHODS_TO_EXCLUDE <- c(
-    'clone'
+    'clone',
+    'print'
 )
 R6_CONSTRUCTOR_NAME <- 'initialize'
 R6_CLASS_METHODS <- c(

--- a/doppel/bin/analyze.R
+++ b/doppel/bin/analyze.R
@@ -157,7 +157,13 @@ for (obj_name in export_names){
                 }
 
                 out[["classes"]][[obj_name]][["public_methods"]][[method_name]] <- list(
-                    "args" = as.list(method_args)
+                    "args" = as.list(
+                        gsub(
+                            "\\.\\.\\."
+                            , KWARGS_STRING
+                            , method_args
+                        )
+                    )
                 )
             }
         }


### PR DESCRIPTION
This is a hotfix to address a few really awful bugs. Badly need tests but the only way I know to effectively test the `analyze.*` scripts is by setting up actual sample packages in `testdata/`. Feel free to contribute to or follow #16 and #17 

Bugs fixed in this:

* `analyze.R` wasn't respecting `--kwargs-string` when R6 class public methods used `...`
* `analyze.R` thought `print()` was an API mismatch when it's actually a special method in R6 equivalent to `__str__()` in Python classes
* `analyze.py` wasn't accounting for the possibility of inherited class methods