### PR TITLE
Added code coverage on analyze.R (fixes #55)

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -22,6 +22,11 @@ ${CONDA_DIR}/bin/conda install -c r \
     r-lintr \
     r-r6
 
+# Per https://github.com/ContinuumIO/anaconda-issues/issues/9423#issue-325303442,
+# packages that require compilation may fail to find the
+# gcc bundled with conda
+export PATH=${PATH}:${CONDA_DIR}/bin
+
 # Get packages for testing
 ${CONDA_DIR}/bin/Rscript -e "install.packages(c('argparse', 'covr', 'futile.logger'), repos = '${CRAN_MIRROR}')"
 ${CONDA_DIR}/bin/pip install \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -23,7 +23,7 @@ ${CONDA_DIR}/bin/conda install -c r \
     r-r6
 
 # Get packages for testing
-${CONDA_DIR}/bin/Rscript -e "install.packages(c('futile.logger', 'argparse'), repos = '${CRAN_MIRROR}')"
+${CONDA_DIR}/bin/Rscript -e "install.packages(c('argparse', 'covr', 'futile.logger'), repos = '${CRAN_MIRROR}')"
 ${CONDA_DIR}/bin/pip install \
     --user \
     argparse \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -18,13 +18,12 @@ ${CONDA_DIR}/bin/conda info -a
 # Set up R (gulp)
 ${CONDA_DIR}/bin/conda install -c r \
     r-base \
-    r-argparse \
     r-jsonlite \
     r-lintr \
     r-r6
 
 # Get packages for testing
-${CONDA_DIR}/bin/Rscript -e "install.packages('futile.logger', repos = '${CRAN_MIRROR}')"
+${CONDA_DIR}/bin/Rscript -e "install.packages(c('futile.logger', 'argparse'), repos = '${CRAN_MIRROR}')"
 ${CONDA_DIR}/bin/pip install \
     --user \
     argparse \

--- a/.ci/test-analyze-r-coverage.R
+++ b/.ci/test-analyze-r-coverage.R
@@ -1,0 +1,50 @@
+
+parser <- argparse::ArgumentParser()
+parser$add_argument(
+    "--source-dir"
+    , type = "character"
+    , help = "Full path to source code of doppel-cli"
+)
+parser$add_argument(
+    "--fail-under"
+    , type = "integer"
+    , help = "Integer from 0 to 100 indicating the minimum allowable code coverage"
+)
+
+# Grab args (store in constants for easier debugging)
+args <- parser$parse_args()
+SOURCE_DIR <- args[["source_dir"]]
+FAIL_UNDER <- args[["fail_under"]]
+
+SOURCE_FILE <- c(
+    file.path(SOURCE_DIR, "doppel", "bin", "analyze.R")
+)
+TEST_FILE <- c(
+    file.path(SOURCE_DIR, ".ci", "test-analyze-r.R")
+)
+
+# I don't know why, but calling this source before covr
+# does _something_ to warm the environment in a way that
+# makes the coverage magic work. This means the code in the
+# analyze script gets run three times but whatever, it works.
+sys.source(
+    TEST_FILE
+    , envir = .GlobalEnv
+)
+
+coverage <- covr::file_coverage(
+    source_files = SOURCE_FILE
+    , test_files = TEST_FILE
+)
+
+print(coverage)
+
+total_coverage <- covr::percent_coverage(coverage)
+print(paste0("Total coverage: ", round(total_coverage, 2), "%"))
+
+if (total_coverage < FAIL_UNDER){
+    print("Coverage below threshold. Failing.")
+    quit(save = "no", status = 1)
+}
+
+print("Done testing coverage of analyze.R")

--- a/.ci/test-analyze-r.R
+++ b/.ci/test-analyze-r.R
@@ -1,4 +1,5 @@
 
+library(assertthat)
 library(R6)
 
 # test package stored in integration_tests/test-packages

--- a/.ci/test-analyze-r.R
+++ b/.ci/test-analyze-r.R
@@ -1,0 +1,52 @@
+
+library(R6)
+
+# test package stored in integration_tests/test-packages
+TEST_PACKAGE <- "testpkguno"
+TESTING_DIR <- tempdir()
+ANALYZE_SCRIPT <- file.path(
+    getwd(), "doppel", "bin", "analyze.R"
+)
+
+TEST_VALUES <- list(
+    "pkg" = TEST_PACKAGE,
+    "output_dir" = TESTING_DIR,
+    "kwargs_string" = "~~KWARGS~~",
+    "constructor_string" = "~~CONSTRUCTOR~~"
+)
+
+# override argparse:::Parser
+MockParser <- R6::R6Class(
+    "MockParser",
+    public = list(
+        initialize = function(...){
+            return(invisible(NULL))
+        },
+        parse_args = function(...){
+            print("returning mocked values")
+            return(TEST_VALUES)
+        },
+        add_argument = function(...){
+            return(invisible(NULL))
+        }
+    )
+)
+
+utils::assignInNamespace(
+    x = "Parser"
+    , value = MockParser
+    , ns = "argparse"
+)
+
+x <- tryCatch({
+   sys.source(
+       ANALYZE_SCRIPT
+       , envir = .GlobalEnv
+   )
+}, error = function(e){
+    return(NULL)
+})
+
+.analyze(
+    args = argparse::ArgumentParser()$parse_args()
+)

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -5,7 +5,10 @@ set -e
 
 # Set up environment variables
 CI_TOOLS=$(pwd)/.ci
-MIN_TEST_COVERAGE=95
+
+# Test coverage stuff
+MIN_UNIT_TEST_COVERAGE=95
+MIN_ANALYZE_R_TEST_COVERAGE=90
 
 # Make sure we're living in conda land
 export PATH="$HOME/miniconda/bin:$PATH"
@@ -13,11 +16,15 @@ export PATH="$HOME/miniconda/bin:$PATH"
 ${CI_TOOLS}/lint_py.sh $(pwd)
 ${CI_TOOLS}/lint_r.sh $(pwd)
 ${CI_TOOLS}/check_docs.sh $(pwd)/docs
-${CI_TOOLS}/run_unit_tests.sh ${MIN_TEST_COVERAGE}
+${CI_TOOLS}/run_unit_tests.sh ${MIN_UNIT_TEST_COVERAGE}
 ${CI_TOOLS}/run_smoke_tests.sh $(pwd)/test_data
 
 ${CI_TOOLS}/install_test_packages.sh
 ${CI_TOOLS}/run_integration_tests.sh $(pwd)/test_data
+
+Rscript ${CI_TOOLS}/test-analyze-r-coverage.R \
+    --source-dir $(pwd) \
+    --fail-under ${MIN_ANALYZE_R_TEST_COVERAGE}
 
 # If all is good, we did it!
 exit 0

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## development version
 
+* Restructured the internals used by `doppel-describe` to describe R packages, so that code coverage of that section can be measured. ([#122](https://github.com/jameslamb/doppel-cli/pull/122))
 * All errors comparing public methods or functions are now reported. Previously, if two issues existed (such as "different number of keyword args" and "different order of keyword args"), only one would be reported. ([#121](https://github.com/jameslamb/doppel-cli/pull/121))
 * Fixed bug which could cause `doppel-describe` to run endlessly in the presence of cyclic imports between submodules (e.g. in `pandas`). ([#120](https://github.com/jameslamb/doppel-cli/pull/120))
 * Fixed bug which could cause a `ValueError` in `doppel-describe` when a Python package used CPython and had builtins that could not be inspected. This showed up in popular packages such as `pandas` and `numpy`. ([#94](https://github.com/jameslamb/doppel-cli/pull/94))

--- a/integration_tests/test-packages/r/testpkguno/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkguno/DESCRIPTION
@@ -8,7 +8,7 @@ Author: c(
 Maintainer: James Lamb <jaylamb20@gmail.com>
 Description: First package for testing doppel-cli
 Depends:
-    R
+    R (>= 3.5)
 Imports:
     R6
 License: file LICENSE


### PR DESCRIPTION
In this PR, I had to jump through some hoops to compute code coverage of `analyze.R`. But I think I figured it out!

The diff is hard to read, but basically the code in `analyze.R` had to be wrapped in a function to make it usable by `covr`.

Happy to report that 95% of the code in `analyze.R` is covered by existing tests!