### PR TITLE
Added keyword-only arguments to function signatures (fixes #125)

### DIFF
--- a/doppel/bin/analyze.py
+++ b/doppel/bin/analyze.py
@@ -67,10 +67,10 @@ def _log_warn(msg):
 
 def _get_arg_names(f, kwargs_string):
     """
-    Given a function object, get it's argument names.
+    Given a function object, get its argument names.
     """
     f_dict = inspect.getfullargspec(f)._asdict()
-    args = f_dict['args']
+    args = f_dict['args'] + f_dict['kwonlyargs']
     # deal with people passing "**kwargs"
     if f_dict['varkw'] is not None:
         args.append(kwargs_string)

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/ClassA.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/ClassA.py
@@ -7,7 +7,7 @@ class ClassA:
     story3 = "hello"
     _secret1 = True
 
-    def __init__(self, x, y, z):
+    def __init__(self, x, y, *, z):
         pass
 
     def anarchy(**kwargs):


### PR DESCRIPTION
This is a fix to include keyword-only arguments in the arguments that doppel finds for python signatures.