### PR TITLE
tried to speed up R installs (fixes #139)

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -16,10 +16,14 @@ ${CONDA_DIR}/bin/conda info -a
 
 # Set up R (gulp)
 ${CONDA_DIR}/bin/conda install -c r \
-    r-base \
+    r-assertthat \
+    r-covr \
+    r-futile.logger \
     r-jsonlite \
     r-lintr \
-    r-r6
+    r-r6 \
+    r-roxygen2 \
+    r-testthat
 
 # Per https://github.com/ContinuumIO/anaconda-issues/issues/9423#issue-325303442,
 # packages that require compilation may fail to find the

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -17,13 +17,15 @@ ${CONDA_DIR}/bin/conda info -a
 # Set up R (gulp)
 ${CONDA_DIR}/bin/conda install -c r \
     r-assertthat \
-    r-covr \
-    r-futile.logger \
     r-jsonlite \
     r-lintr \
     r-r6 \
     r-roxygen2 \
     r-testthat
+
+${CONDA_DIR}/bin/conda install -c conda-forge \
+    r-covr \
+    r-futile.logger
 
 # Per https://github.com/ContinuumIO/anaconda-issues/issues/9423#issue-325303442,
 # packages that require compilation may fail to find the

--- a/.ci/test-analyze-r-coverage.R
+++ b/.ci/test-analyze-r-coverage.R
@@ -1,4 +1,7 @@
 
+library(argparse)
+library(covr)
+
 parser <- argparse::ArgumentParser()
 parser$add_argument(
     "--source-dir"

--- a/.ci/test-analyze-r.R
+++ b/.ci/test-analyze-r.R
@@ -1,6 +1,5 @@
 
 library(argparse)
-library(assertthat)
 library(R6)
 
 # test package stored in integration_tests/test-packages


### PR DESCRIPTION
`r-base` is a somewhat heavy dependency. I noticed a lot of unnecessary stuff like `rstudioapi` getting installed. Trying, in this PR, to pare down this project's CI to the absolute minimum dependencies