### PR TITLE
removed duplicate R installs from setup.sh (fixes #142)

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -31,10 +31,11 @@ ${CONDA_DIR}/bin/conda install -c conda-forge \
 # Per https://github.com/ContinuumIO/anaconda-issues/issues/9423#issue-325303442,
 # packages that require compilation may fail to find the
 # gcc bundled with conda
+
 export PATH=${PATH}:${CONDA_DIR}/bin
 
 # Get R packages for testing
-${CONDA_DIR}/bin/Rscript -e "install.packages(c('roxygen2'), repos = '${CRAN_MIRROR}')"
+#${CONDA_DIR}/bin/Rscript -e "install.packages(c('roxygen2'), repos = '${CRAN_MIRROR}')"
 
 # Get Python packages for testing
 ${CONDA_DIR}/bin/pip install \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -33,7 +33,7 @@ ${CONDA_DIR}/bin/conda install -c conda-forge \
 export PATH=${PATH}:${CONDA_DIR}/bin
 
 # Get R packages for testing
-${CONDA_DIR}/bin/Rscript -e "install.packages(c('argparse', 'covr', 'futile.logger', 'roxygen2'), repos = '${CRAN_MIRROR}')"
+#${CONDA_DIR}/bin/Rscript -e "install.packages(c('argparse', 'covr', 'futile.logger', 'roxygen2'), repos = '${CRAN_MIRROR}')"
 
 # Get Python packages for testing
 ${CONDA_DIR}/bin/pip install \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -33,7 +33,7 @@ ${CONDA_DIR}/bin/conda install -c conda-forge \
 export PATH=${PATH}:${CONDA_DIR}/bin
 
 # Get R packages for testing
-#${CONDA_DIR}/bin/Rscript -e "install.packages(c('argparse', 'covr', 'futile.logger', 'roxygen2'), repos = '${CRAN_MIRROR}')"
+${CONDA_DIR}/bin/Rscript -e "install.packages(c('argparse', 'roxygen2'), repos = '${CRAN_MIRROR}')"
 
 # Get Python packages for testing
 ${CONDA_DIR}/bin/pip install \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -25,6 +25,7 @@ ${CONDA_DIR}/bin/conda install -c r \
 
 ${CONDA_DIR}/bin/conda install -c conda-forge \
     r-covr \
+    r-argparse \
     r-futile.logger
 
 # Per https://github.com/ContinuumIO/anaconda-issues/issues/9423#issue-325303442,
@@ -33,7 +34,7 @@ ${CONDA_DIR}/bin/conda install -c conda-forge \
 export PATH=${PATH}:${CONDA_DIR}/bin
 
 # Get R packages for testing
-${CONDA_DIR}/bin/Rscript -e "install.packages(c('argparse', 'roxygen2'), repos = '${CRAN_MIRROR}')"
+${CONDA_DIR}/bin/Rscript -e "install.packages(c('roxygen2'), repos = '${CRAN_MIRROR}')"
 
 # Get Python packages for testing
 ${CONDA_DIR}/bin/pip install \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -34,9 +34,6 @@ ${CONDA_DIR}/bin/conda install -c conda-forge \
 
 export PATH=${PATH}:${CONDA_DIR}/bin
 
-# Get R packages for testing
-#${CONDA_DIR}/bin/Rscript -e "install.packages(c('roxygen2'), repos = '${CRAN_MIRROR}')"
-
 # Get Python packages for testing
 ${CONDA_DIR}/bin/pip install \
     --user \

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup
 from setuptools import find_packages
 
+python_requires='>=3.5'
+
 with open('README.md', 'r') as f:
     readme = f.read()
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup
 from setuptools import find_packages
 
-python_requires='>=3.5'
-
 with open('README.md', 'r') as f:
     readme = f.read()
 


### PR DESCRIPTION
This should fix issue #142 . 

Simply removing the whole install.packages() line resulted in an error related to argparse not being recognised. I thus added this item to the conda install after removing the install.packages() line. 

This has resulted in a roughly 30s decrease in run time for each individual Travis build job, with ~1.5min decrease in the aggregated build run time, and ~2.5min decrease in the total time.

Let me know if you need any edits! 