### PR TITLE
[ci] added tests on analyze.py handling of Python built-ins

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -14,7 +14,7 @@ CI_TOOLS=$(pwd)/.ci
 # Test coverage stuff
 MIN_UNIT_TEST_COVERAGE=95
 MIN_ANALYZE_R_TEST_COVERAGE=100
-MIN_ANALYZE_PY_TEST_COVERAGE=90
+MIN_ANALYZE_PY_TEST_COVERAGE=97
 
 # Make sure we're living in conda land
 export PATH="$HOME/miniconda/bin:$PATH"

--- a/integration_tests/python_tests/test_analyze.py
+++ b/integration_tests/python_tests/test_analyze.py
@@ -341,7 +341,7 @@ class TestClassOnly:
         assert len(result_json.keys()) == NUM_TOP_LEVEL_KEYS
 
 
-class PythonSpecific:
+class TestPythonSpecific:
     """
     Test the behavior of analyze.py for packages
     with some Python-specific features like
@@ -366,8 +366,8 @@ class PythonSpecific:
         """
         result_json = rundescribe['pythonspecific']
 
-        assert set(result_json['functions'].keys()) == set(['some_function'])
-        assert set(result_json['classes'].keys()) == set(['SomeClass', 'GreatClass'])
+        assert set(result_json['functions'].keys()) == set(['some_function', 'wrap_min'])
+        assert set(result_json['classes'].keys()) == set(['SomeClass', 'GreatClass', 'MinWrapper'])
 
     def test_inner_classes(self, rundescribe):
         """
@@ -377,6 +377,25 @@ class PythonSpecific:
         """
         result_json = rundescribe['pythonspecific']
 
-        assert set(result_json['classes']['GreatClass']['public_methods'].keys()) == set(['do_stuff', 'LilGreatClass'])
-        lil_args = result_json['classes']['GreatClass']['public_methods']['LilGreatClass']
-        assert set(lil_args) == ['things', 'stuff']
+        assert set(result_json['classes']['GreatClass']['public_methods'].keys()) == set(['do_stuff', 'LilGreatClass', '~~CONSTRUCTOR~~'])
+        lil_args = result_json['classes']['GreatClass']['public_methods']['LilGreatClass']['args']
+        assert set(lil_args) == set(['things', 'stuff'])
+
+    def test_builtin_func(self, rundescribe):
+        """
+        analyze.py should correctly handle the case where a built-in
+        like min() has been mapped directly to an exported function
+        """
+        result_json = rundescribe['pythonspecific']
+
+        assert result_json['functions']['wrap_min'] == {'args': []}
+
+    def test_builtin_method(self, rundescribe):
+        """
+        analyze.py should correctly handle the case where a built-in
+        like min() has been mapped directly to a public method
+        of a class
+        """
+        result_json = rundescribe['pythonspecific']
+
+        assert result_json['classes']['MinWrapper']['public_methods']['wrap_min'] == {'args': []}

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/__init__.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/__init__.py
@@ -2,3 +2,5 @@
 from .some_function import some_function
 from .SomeClass import SomeClass
 from .SomeClass import SOME_CONSTANT
+from .wrap_min import wrap_min
+from .wrap_min import MinWrapper

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/wrap_min.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/wrap_min.py
@@ -1,0 +1,9 @@
+
+# used to test the "cannot get signature of builtin" code
+wrap_min = min
+
+
+class MinWrapper:
+    def __init__(self):
+        pass
+    wrap_min = min

--- a/integration_tests/test-packages/r/testpkgdos/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkgdos/DESCRIPTION
@@ -13,4 +13,4 @@ Depends:
     R (>= 3.5)
 License: file LICENSE
 VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2

--- a/integration_tests/test-packages/r/testpkgtres/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkgtres/DESCRIPTION
@@ -15,4 +15,4 @@ Imports:
     R6
 License: file LICENSE
 VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2

--- a/integration_tests/test-packages/r/testpkguno/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkguno/DESCRIPTION
@@ -13,4 +13,4 @@ Imports:
     R6
 License: file LICENSE
 VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2


### PR DESCRIPTION
The tests in this PR take us to 98% coverage of `analyze.py`! It also fixes a bug in the tests, where tests on `pythonspecific` were not actually being run because the test class's name didn't start with `Test`.

```
platform darwin -- Python 3.6.7, pytest-5.0.1, py-1.5.4, pluggy-0.12.0
rootdir: /Users/jlamb/repos/doppel-cli
plugins: cov-2.7.1
collected 1 item

test_analyze_py.py .                                                     [100%]

---------- coverage: platform darwin, python 3.6.7-final-0 -----------
Name                Stmts   Miss  Cover
---------------------------------------
doppel_analyze.py     126      3    98%


=========================== 1 passed in 0.09 seconds ===========================
Name                Stmts   Miss  Cover   Missing
-------------------------------------------------
doppel_analyze.py     126      3    98%   274, 303-304
```