### PR TITLE
[ci] Added tests on re-use of modules in Python (fixes #135)

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -12,9 +12,9 @@ set -e
 CI_TOOLS=$(pwd)/.ci
 
 # Test coverage stuff
-MIN_UNIT_TEST_COVERAGE=95
+MIN_UNIT_TEST_COVERAGE=100
 MIN_ANALYZE_R_TEST_COVERAGE=100
-MIN_ANALYZE_PY_TEST_COVERAGE=97
+MIN_ANALYZE_PY_TEST_COVERAGE=100
 
 # Make sure we're living in conda land
 export PATH="$HOME/miniconda/bin:$PATH"

--- a/doppel/bin/analyze.py
+++ b/doppel/bin/analyze.py
@@ -298,7 +298,7 @@ def do_everything(parsed_args):
 # Structuring things like this so it can be instrumented
 # for test coverage.
 # See https://stackoverflow.com/a/18161115 for more
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
 
     parsed_args = parse_args(sys.argv[1:])
     do_everything(parsed_args)

--- a/doppel/reporters.py
+++ b/doppel/reporters.py
@@ -77,11 +77,11 @@ class SimpleReporter:
         # Finally
         self._respond()
 
-    def _respond(self):
+    def _respond(self):  # pragma: no cover
         """
         After all evaluations, determine final exit status.
 
-        This down here in a separate method so that it can later
+        This is down here in a separate method so that it can later
         be extended to handle configuration like "skip these particular
         methods".
         """

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/__init__.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/__init__.py
@@ -4,3 +4,4 @@ from pythonspecific.SomeException import SomeException
 # sub-modules
 import pythonspecific.mod_one
 import pythonspecific.mod_two
+import pythonspecific.mod_three

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_three/__init__.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_three/__init__.py
@@ -1,0 +1,4 @@
+
+# adding this to trigger the code that checks for
+# a module that has already been parsed once
+from pythonspecific import mod_two

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -117,6 +117,34 @@ for i in range(5):
 PACKAGE_BEEFY2 = copy.deepcopy(PACKAGE_BEEFY)
 PACKAGE_BEEFY2['name'] = 'pkg2'
 
+PACKAGE_DIFFERENT_METHODS_1 = {
+    "name": "py_pkg",
+    "language": "python",
+    "functions": {},
+    "classes": {
+        "SomeClass": {
+            "public_methods": {
+                "~~CONSTRUCTOR~~": {
+                    "args": []
+                },
+                "write_py": {
+                    "args": ["x", "y"]
+                }
+            }
+        }
+    }
+}
+PACKAGE_DIFFERENT_METHODS_2 = copy.deepcopy(PACKAGE_DIFFERENT_METHODS_1)
+del PACKAGE_DIFFERENT_METHODS_2['classes']['SomeClass']['public_methods']['write_py']
+PACKAGE_DIFFERENT_METHODS_2['classes']['SomeClass']['public_methods'].update({
+    "write_r": {
+        "args": ["x", "y"]
+    }
+})
+PACKAGE_DIFFERENT_METHODS_2.update({
+    "name": "r_pkg"
+})
+
 
 class TestSimpleReporter(unittest.TestCase):
 
@@ -133,7 +161,7 @@ class TestSimpleReporter(unittest.TestCase):
         reporter._check_function_args()
         errors = reporter.errors
         self.assertTrue(
-            len(errors) == 3,
+            len(errors) == 3
         )
         self.assertTrue(
             all([isinstance(x, DoppelTestError) for x in errors])
@@ -156,7 +184,7 @@ class TestSimpleReporter(unittest.TestCase):
         reporter._check_function_args()
         errors = reporter.errors
         self.assertTrue(
-            len(errors) == 2,
+            len(errors) == 2
         )
         self.assertTrue(
             all([isinstance(x, DoppelTestError) for x in errors])
@@ -178,7 +206,7 @@ class TestSimpleReporter(unittest.TestCase):
         reporter._check_function_args()
         errors = reporter.errors
         self.assertTrue(
-            len(errors) == 1,
+            len(errors) == 1
         )
         self.assertTrue(
             all([isinstance(x, DoppelTestError) for x in errors])
@@ -200,7 +228,7 @@ class TestSimpleReporter(unittest.TestCase):
         reporter._check_function_args()
         errors = reporter.errors
         self.assertTrue(
-            len(errors) == 3,
+            len(errors) == 3
         )
         self.assertTrue(
             all([isinstance(x, DoppelTestError) for x in errors])
@@ -221,7 +249,7 @@ class TestSimpleReporter(unittest.TestCase):
         reporter._check_function_args()
         errors = reporter.errors
         self.assertTrue(
-            len(errors) == 0,
+            len(errors) == 0
         )
 
     def test_public_method_arg_number(self):
@@ -237,7 +265,7 @@ class TestSimpleReporter(unittest.TestCase):
         reporter._check_class_public_method_args()
         errors = reporter.errors
         self.assertTrue(
-            len(errors) == 3,
+            len(errors) == 3
         )
         self.assertTrue(
             all([isinstance(x, DoppelTestError) for x in errors])
@@ -260,7 +288,7 @@ class TestSimpleReporter(unittest.TestCase):
         reporter._check_class_public_method_args()
         errors = reporter.errors
         self.assertTrue(
-            len(errors) == 2,
+            len(errors) == 2
         )
         self.assertTrue(
             all([isinstance(x, DoppelTestError) for x in errors])
@@ -282,13 +310,38 @@ class TestSimpleReporter(unittest.TestCase):
         reporter._check_class_public_method_args()
         errors = reporter.errors
         self.assertTrue(
-            len(errors) == 1,
+            len(errors) == 1
         )
         self.assertTrue(
             all([isinstance(x, DoppelTestError) for x in errors])
         )
         self.assertTrue(
             errors[0].msg == "Public method 'no_days_off()' on class 'WaleFolarin' exists in all packages but with differing order of keyword arguments."
+        )
+
+    def test_different_public_methods(self):
+        """
+        SimpleReporter should handle the case where a class exists
+        in both packages, with the same number of public methods,
+        but with different methods.
+        """
+        reporter = SimpleReporter(
+            pkgs=[
+                PackageAPI(PACKAGE_DIFFERENT_METHODS_1),
+                PackageAPI(PACKAGE_DIFFERENT_METHODS_2)
+            ],
+            errors_allowed=2
+        )
+        reporter._check_class_public_methods()
+        errors = reporter.errors
+        self.assertTrue(
+            len(errors) == 2
+        )
+        self.assertTrue(
+            all([isinstance(x, DoppelTestError) for x in errors])
+        )
+        self.assertTrue(
+            errors[0].msg.startswith("Not all implementations of class 'SomeClass' have public method")
         )
 
     def test_totally_empty(self):

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -155,7 +155,10 @@ class TestSimpleReporter(unittest.TestCase):
         number of keyword arguments.
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_NUMBER)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE),
+                PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_NUMBER)
+            ],
             errors_allowed=100
         )
         reporter._check_function_args()
@@ -178,7 +181,10 @@ class TestSimpleReporter(unittest.TestCase):
         of arguments)
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARGS)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE),
+                PackageAPI(PACKAGE_WITH_DIFFERENT_ARGS)
+            ],
             errors_allowed=100
         )
         reporter._check_function_args()
@@ -200,7 +206,10 @@ class TestSimpleReporter(unittest.TestCase):
         both packages but they are in different orders'
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_ORDER)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE),
+                PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_ORDER)
+            ],
             errors_allowed=100
         )
         reporter._check_function_args()
@@ -222,7 +231,10 @@ class TestSimpleReporter(unittest.TestCase):
         and different order.
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_SUPER_DIFFERENT)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE),
+                PackageAPI(PACKAGE_SUPER_DIFFERENT)
+            ],
             errors_allowed=100
         )
         reporter._check_function_args()
@@ -243,7 +255,10 @@ class TestSimpleReporter(unittest.TestCase):
         if the shared function is the same in both packages.
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(BASE_PACKAGE2)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE),
+                PackageAPI(BASE_PACKAGE2)
+            ],
             errors_allowed=0
         )
         reporter._check_function_args()
@@ -259,7 +274,10 @@ class TestSimpleReporter(unittest.TestCase):
         in two packages have different number of keyword arguments
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE_WITH_CLASSES), PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE_WITH_CLASSES),
+                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER)
+            ],
             errors_allowed=100
         )
         reporter._check_class_public_method_args()
@@ -282,7 +300,10 @@ class TestSimpleReporter(unittest.TestCase):
         they have the same number of arguments)
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE_WITH_CLASSES), PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARGS)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE_WITH_CLASSES),
+                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARGS)
+            ],
             errors_allowed=100
         )
         reporter._check_class_public_method_args()
@@ -304,7 +325,10 @@ class TestSimpleReporter(unittest.TestCase):
         both packages but they are in different orders'
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE_WITH_CLASSES), PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE_WITH_CLASSES),
+                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER)
+            ],
             errors_allowed=100
         )
         reporter._check_class_public_method_args()
@@ -350,7 +374,10 @@ class TestSimpleReporter(unittest.TestCase):
         are totally empty.
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(PACKAGE_EMPTY), PackageAPI(PACKAGE_EMPTY2)],
+            pkgs=[
+                PackageAPI(PACKAGE_EMPTY),
+                PackageAPI(PACKAGE_EMPTY2)
+            ],
             errors_allowed=0
         )
         reporter._check_function_args()
@@ -361,7 +388,10 @@ class TestSimpleReporter(unittest.TestCase):
         SimpleReporter should run end-to-end without error
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(PACKAGE_BEEFY), PackageAPI(PACKAGE_SUPER_DIFFERENT)],
+            pkgs=[
+                PackageAPI(PACKAGE_BEEFY),
+                PackageAPI(PACKAGE_SUPER_DIFFERENT)
+            ],
             errors_allowed=100
         )
 
@@ -381,7 +411,10 @@ class TestSimpleReporter(unittest.TestCase):
         on shared classes and functions)
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(PACKAGE_BEEFY), PackageAPI(PACKAGE_BEEFY2)],
+            pkgs=[
+                PackageAPI(PACKAGE_BEEFY),
+                PackageAPI(PACKAGE_BEEFY2)
+            ],
             errors_allowed=100
         )
 
@@ -400,7 +433,9 @@ class TestSimpleReporter(unittest.TestCase):
         only use a single package
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE_WITH_CLASSES)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE_WITH_CLASSES)
+            ],
             errors_allowed=0
         )
 


### PR DESCRIPTION
This PR introduces some code to the test package `pythonspecific` to cover the branch in `analyze.py` that avoids parsing a module that has already been parsed. This is a real scenario that I've observed in packages like `pandas`.

The code being covered by these tests was introduced in #120, see there for more.