### PR TITLE
Fixed regression in handling of imports (fixes #160)

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -42,6 +42,7 @@ ${CONDA_DIR}/bin/pip install \
     coverage \
     codecov \
     pycodestyle \
+    requests \
     sphinx \
     sphinx_autodoc_typehints \
     sphinx_rtd_theme \

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@
 **/*.ipynb
 
 # R files
+**/*.Renviron
 **/*.Rhistory
+**/*.Rprofile
 **/*.rda
 **/*.rds
 **/*.Rdata

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       install:
         - /Users/travis/miniconda3/bin/conda create -q -n testenv python=3.6 nose pytest
         - source activate testenv
-        - pip install argparse
+        - pip install argparse requests
         - python setup.py install
     - os: linux
       language: python

--- a/doppel/bin/analyze.py
+++ b/doppel/bin/analyze.py
@@ -282,10 +282,6 @@ def do_everything(parsed_args):
             elif _is_builtin(obj) and callable(obj):
                 if not obj.__module__.startswith(PKG_NAME):
                     _log_info("Callable '{}' is a built-in not included in this package's namespace. Skipping it.".format(obj.__name__))
-                else:
-                    out["functions"][obj_name] = {
-                        "args": []
-                    }
                 next
 
             else:

--- a/doppel/bin/analyze.py
+++ b/doppel/bin/analyze.py
@@ -280,9 +280,13 @@ def do_everything(parsed_args):
             # according to the previous checks, but if they're callable
             # they should count as exported functions
             elif _is_builtin(obj) and callable(obj):
-                out["functions"][obj_name] = {
-                    "args": []
-                }
+                if not obj.__module__.startswith(PKG_NAME):
+                    _log_info("Callable '{}' is a built-in not included in this package's namespace. Skipping it.".format(obj.__name__))
+                else:
+                    out["functions"][obj_name] = {
+                        "args": []
+                    }
+                next
 
             else:
                 _log_info("Could not figure out what {} is".format(obj_name))

--- a/integration_tests/test-packages/python/pythonspecific2/pythonspecific2/__init__.py
+++ b/integration_tests/test-packages/python/pythonspecific2/pythonspecific2/__init__.py
@@ -1,0 +1,6 @@
+__all__ = [
+    'create_warning',
+    'custom_post'
+]
+
+from .module import *

--- a/integration_tests/test-packages/python/pythonspecific2/pythonspecific2/module.py
+++ b/integration_tests/test-packages/python/pythonspecific2/pythonspecific2/module.py
@@ -1,0 +1,19 @@
+from warnings import warn
+from requests import get
+from requests import post as custom_post
+
+
+def create_warning():
+    print('uh oh')
+    warn('not good')
+
+
+shmeate_schmarning = warn
+
+
+def create_warm_things(**kwargs):
+    warn(**kwargs)
+
+
+def _super_secret():
+    print('shhhh')

--- a/integration_tests/test-packages/python/pythonspecific2/setup.py
+++ b/integration_tests/test-packages/python/pythonspecific2/setup.py
@@ -1,0 +1,9 @@
+from setuptools import find_packages
+from setuptools import setup
+
+
+setup(
+    name='pythonspecific2',
+    version='0.0.1',
+    packages=find_packages(),
+)


### PR DESCRIPTION
In this PR, I attempted to fix the issue @austin3dickey raised in #160 . The fix here returns `doppel-cli`'s handling of standard-lib functions (e.g. `from warnings import warn`)  to the previous behavior.

I added @austin3dickey's reproducible example as a test package and added tests on it. Note that in those tests, I'm not taking a stand on what the behavior _should_ be, just trying to document the current behavior so regressions like this aren't accidentally introduced in the future.

For example, right now I know that `doppel-cli` isn't doing the "right" thing for a package like `feather`, where it seems obvious that [they are trying to "re-export" from other packages](https://github.com/wesm/feather/blob/master/python/feather/api.py#L15)

```python
from pyarrow.feather import (read_feather as read_dataframe,  # noqa
                             write_feather as write_dataframe,
                             FeatherError,
                             FeatherReader,
                             FeatherWriter)
```

As of this commit, running`doppel-describe -p pythonspecific2 -l python -d out/` yields:

```
{
  "name": "pythonspecific2 [python]",
  "language": "python",
  "functions": {
    "create_warm_things": {
      "args": [
        "~~KWARGS~~"
      ]
    },
    "create_warning": {
      "args": []
    }
  },
  "classes": {}
}
```

I tested with `doppel-cli==0.2.1` and got the exact same output.

The tests are passing for the other built-in cases I tried to address in  #155 so I don't think this is undoing that work.
