### PR TITLE
made required things required (fixes #168)

### DIFF
--- a/doppel/cli.py
+++ b/doppel/cli.py
@@ -9,7 +9,8 @@ from doppel.PackageAPI import PackageAPI
 @click.option(
     '--files', '-f',
     default=None,
-    help="Comma-delimited list of doppel output files."
+    help="Comma-delimited list of doppel output files.",
+    required=True
 )
 @click.option(
     '--errors-allowed',

--- a/doppel/cli.py
+++ b/doppel/cli.py
@@ -9,8 +9,7 @@ from doppel.PackageAPI import PackageAPI
 @click.option(
     '--files', '-f',
     default=None,
-    help="Comma-delimited list of doppel output files.",
-    required=True
+    help="Comma-delimited list of doppel output files."
 )
 @click.option(
     '--errors-allowed',
@@ -47,6 +46,9 @@ def main(files: str, errors_allowed: int, version: bool) -> None:
             out = f.read()
         stdout.write(out)
         return
+
+    if files is None:
+        raise RuntimeError('Missing option "--files"')
 
     print("Loading comparison files")
 

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -14,18 +14,18 @@ logging.basicConfig(
 @click.command()
 @click.option(
     '--language', '-l',
-    help="Programming language. Currently python and R are supported.",
-    required=True
+    default=None,
+    help="Programming language. Currently python and R are supported."
 )
 @click.option(
     '--pkg_name', '-p',
-    help="Name of a package",
-    required=True
+    default=None,
+    help="Name of a package"
 )
 @click.option(
     '--data-dir', '-d',
+    default=None,
     help="Path to write output file to.",
-    required=True
 )
 @click.option(
     '--version',
@@ -53,6 +53,15 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
             out = f.read()
         stdout.write(out)
         return
+
+    if language is None:
+        raise RuntimeError('Missing option "--language"')
+
+    if pkg_name is None:
+        raise RuntimeError('Missing option "--pkg_name"')
+
+    if data_dir is None:
+        raise RuntimeError('Missing option "--data-dir"')
 
     if verbose is True:
         logger.setLevel(logging.DEBUG)

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -14,15 +14,18 @@ logging.basicConfig(
 @click.command()
 @click.option(
     '--language', '-l',
-    help="Programming language. Currently python and R are supported."
+    help="Programming language. Currently python and R are supported.",
+    required=True
 )
 @click.option(
     '--pkg_name', '-p',
-    help="Name of a package"
+    help="Name of a package",
+    required=True
 )
 @click.option(
     '--data-dir', '-d',
-    help="Path to write output file to."
+    help="Path to write output file to.",
+    required=True
 )
 @click.option(
     '--version',

--- a/integration_tests/python_tests/test_analyze.py
+++ b/integration_tests/python_tests/test_analyze.py
@@ -9,6 +9,7 @@ import os
 import pytest
 import re
 import subprocess
+import uuid
 
 # details that will always be true of doppel-describe output
 EXPECTED_TOP_LEVEL_KEYS = set([
@@ -99,7 +100,7 @@ class TestBadDataDir:
             'doppel-describe',
             '--language', 'python',
             '-p', 'testpkguno',
-            '--data-dir', 'random-nonexistent-dir'
+            '--data-dir', str(uuid.uuid4())
         ], stderr=subprocess.PIPE)
         error_text = result.stderr.decode('utf-8')
         assert bool(re.search('passed to --data-dir does not exist', error_text))
@@ -545,10 +546,7 @@ class TestMissingFiles:
         '--files' should be required
         """
         result = subprocess.run([
-            'doppel-describe',
-            '--language', 'python',
-            '-p', 'testpkguno',
-            '--data-dir', 'random-nonexistent-dir'
+            'doppel-test',
         ], stderr=subprocess.PIPE)
         error_text = result.stderr.decode('utf-8')
         assert bool(re.search('Missing option "--files"', error_text))

--- a/integration_tests/python_tests/test_analyze.py
+++ b/integration_tests/python_tests/test_analyze.py
@@ -497,3 +497,58 @@ class TestWeirdImportStuff:
         """
         result_json = rundescribe['pythonspecific2']
         assert result_json['classes'] == {}
+
+
+class TestMissingFiles:
+    """
+    An informative error should be thrown immediately if
+    you do not provide any of the required arguments.
+    """
+    def test_describe_no_package(self):
+        """
+        '-p' should be required
+        """
+        result = subprocess.run([
+            'doppel-describe',
+            '--language', 'python',
+            '--data-dir', '../../test_data'
+        ], stderr=subprocess.PIPE)
+        error_text = result.stderr.decode('utf-8')
+        assert bool(re.search('Missing option "--pkg_name"', error_text))
+
+    def test_describe_no_language(self):
+        """
+        '-l' should be required
+        """
+        result = subprocess.run([
+            'doppel-describe',
+            '-p', 'argparse',
+            '--data-dir', '../../test_data'
+        ], stderr=subprocess.PIPE)
+        error_text = result.stderr.decode('utf-8')
+        assert bool(re.search('Missing option "--language"', error_text))
+
+    def test_describe_no_data_dir(self):
+        """
+        '--data-dir' should be required
+        """
+        result = subprocess.run([
+            'doppel-describe',
+            '--pkg_name', 'argparse',
+            '-l', 'python'
+        ], stderr=subprocess.PIPE)
+        error_text = result.stderr.decode('utf-8')
+        assert bool(re.search('Missing option "--data-dir"', error_text))
+
+    def test_no_files(self):
+        """
+        '--files' should be required
+        """
+        result = subprocess.run([
+            'doppel-describe',
+            '--language', 'python',
+            '-p', 'testpkguno',
+            '--data-dir', 'random-nonexistent-dir'
+        ], stderr=subprocess.PIPE)
+        error_text = result.stderr.decode('utf-8')
+        assert bool(re.search('Missing option "--files"', error_text))

--- a/integration_tests/test-packages/r/testpkgdos/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkgdos/DESCRIPTION
@@ -13,4 +13,4 @@ Depends:
     R (>= 3.5)
 License: file LICENSE
 VignetteBuilder: knitr
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/integration_tests/test-packages/r/testpkgtres/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkgtres/DESCRIPTION
@@ -15,4 +15,4 @@ Imports:
     R6
 License: file LICENSE
 VignetteBuilder: knitr
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/integration_tests/test-packages/r/testpkguno/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkguno/DESCRIPTION
@@ -13,4 +13,4 @@ Imports:
     R6
 License: file LICENSE
 VignetteBuilder: knitr
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0


### PR DESCRIPTION
Right now all CLI options (both in `doppel-describe` and `doppel-test`) are  just that..."options". Some of them are absolutely necessary for `doppel-cli`, but today  you only find that out by getting weird downstream errors.

This PR fixes  that.