### PR TITLE
document R6 stuff (fixes #153)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ smoke_tests/test_data/results.txt
 **/coverage.html
 lib/
 integration_tests/r_tests/thing.txt
+**/.mypy_cache/
 
 # temporary file created by .ci/run_analyze_py_coverage.sh
 .ci/analyze_py_tests/doppel_analyze.py

--- a/integration_tests/test-packages/r/testpkgdos/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkgdos/DESCRIPTION
@@ -14,3 +14,4 @@ Depends:
 License: file LICENSE
 VignetteBuilder: knitr
 RoxygenNote: 7.1.0
+Encoding: UTF-8

--- a/integration_tests/test-packages/r/testpkgtres/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkgtres/DESCRIPTION
@@ -16,3 +16,4 @@ Imports:
 License: file LICENSE
 VignetteBuilder: knitr
 RoxygenNote: 7.1.0
+Encoding: UTF-8

--- a/integration_tests/test-packages/r/testpkgtres/R/SomeClass.R
+++ b/integration_tests/test-packages/r/testpkgtres/R/SomeClass.R
@@ -7,9 +7,14 @@
 SomeClass <- R6::R6Class(
     "SomeClass",
     public = list(
+
+        #' @description create a SomeClass
         initialize = function() {
             return(invisible(NULL))
         },
+
+        #' @description gr8 code
+        #' @param x x
         some_method = function(x) {
             return(x + 5L)
         }

--- a/integration_tests/test-packages/r/testpkguno/DESCRIPTION
+++ b/integration_tests/test-packages/r/testpkguno/DESCRIPTION
@@ -14,3 +14,4 @@ Imports:
 License: file LICENSE
 VignetteBuilder: knitr
 RoxygenNote: 7.1.0
+Encoding: UTF-8

--- a/integration_tests/test-packages/r/testpkguno/R/ClassA.R
+++ b/integration_tests/test-packages/r/testpkguno/R/ClassA.R
@@ -8,22 +8,41 @@ ClassA <- R6::R6Class(
     classname = "ClassA",
     public = list(
 
+        #' @field story1 a story
         story1 = TRUE,
+
+        #' @field story2 another story
         story2 = 5.0,
+
+        #' @field story3 the third story
         story3 = "hello",
 
+        #' @description create a ClassA
+        #' @param x x
+        #' @param y y
+        #' @param z z
         initialize = function(x, y, z) {
             return(invisible(NULL))
         },
 
+        #' @description anarchy
+        #' @param ... dotz
         anarchy = function(...) {
             return(invisible(NULL))
         },
 
+        #' @description banarchy
+        #' @param thing_1 thing_1
+        #' @param thing_2 thing_2
+        #' @param yes yes
         banarchy = function(thing_1, thing_2, yes) {
             return(invisible(NULL))
         },
 
+        #' @description canarchy
+        #' @param x x
+        #' @param y y
+        #' @param ... dotz
         canarchy = function(x, y, ...) {
             return(invisible(NULL))
         }
@@ -31,6 +50,7 @@ ClassA <- R6::R6Class(
 
     active = list(
 
+        #' @field number_four the fourth number
         number_four = function() {
             return(4L)
         }

--- a/integration_tests/test-packages/r/testpkguno/R/ClassB.R
+++ b/integration_tests/test-packages/r/testpkguno/R/ClassB.R
@@ -10,17 +10,22 @@ ClassB <- R6::R6Class(
 
     public = list(
 
+        #' @description ClassB
+        #' @param ... dotz
         initialize = function(...) {
             return(invisible(NULL))
         },
 
-        # Overwriting one method from ClassA to
-        # test that ordering of inheritance is
-        # respected
+        #' @description Overwriting one method from ClassA to
+        #'              test that ordering of inheritance is
+        #'              respected
+        #' @param nonsense nonsense
         banarchy = function(nonsense = TRUE) {
             return(nonsense)
         },
 
+        #' @description oh hello
+        #' @param greeting greeting
         hello_there = function(greeting) {
             return(invisible(NULL))
         }

--- a/integration_tests/test-packages/r/testpkguno/R/ClassC.R
+++ b/integration_tests/test-packages/r/testpkguno/R/ClassC.R
@@ -7,6 +7,9 @@
 ClassC <- R6::R6Class(
     classname = "ClassC",
     public = list(
+
+        #' @description create a ClassC
+        #' @param ... dotz
         initialize = function(...) {
             return(invisible(NULL))
         }

--- a/integration_tests/test-packages/r/testpkguno/R/ClassD.R
+++ b/integration_tests/test-packages/r/testpkguno/R/ClassD.R
@@ -8,11 +8,17 @@ ClassD <- R6::R6Class(
     classname = "ClassD",
     inherit = ClassC,
     public = list(
+        #' @field x x
         x = NULL,
+
+        #' @description create a ClassD
+        #' @param x x
         initialize = function(x) {
             self[["x"]] <- x
             return(invisible(NULL))
         },
+
+        #' @description print a ClassD instance
         print = function() {
             return(invisible(NULL))
         }

--- a/integration_tests/test-packages/r/testpkguno/R/ClassE.R
+++ b/integration_tests/test-packages/r/testpkguno/R/ClassE.R
@@ -9,6 +9,7 @@
 ClassE <- R6::R6Class(
     classname = "ClassE",
     public = list(
+        #' @description create a ClassE
         initialize = function() {
             return(invisible(NULL))
         }


### PR DESCRIPTION
See #153 . This doesn't change `doppel-cli`'s functionality, but removes some warnings from the logs in CI.