### PR TITLE
[ci] add mypy and black (fixes #184)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,10 +11,10 @@ branches:
 environment:
   matrix:
     - PYTHON: C:\Python35-x64
-      PYTHON_VERSION: 3.5
+      PYTHON_VERSION: 3.6
       PYTHON_ARCH: 64
     - PYTHON: C:\Python36-x64
-      PYTHON_VERSION: 3.6
+      PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,9 +10,6 @@ branches:
 
 environment:
   matrix:
-    - PYTHON: C:\Python35-x64
-      PYTHON_VERSION: 3.6
-      PYTHON_ARCH: 64
     - PYTHON: C:\Python36-x64
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64

--- a/.ci/analyze_py_tests/test_analyze_py.py
+++ b/.ci/analyze_py_tests/test_analyze_py.py
@@ -1,4 +1,3 @@
-
 import json
 import os
 
@@ -10,12 +9,7 @@ except ModuleNotFoundError:
 
 class TestAnalyzePy:
 
-    TEST_PACKAGES = [
-        "testpkguno",
-        "testpkgdos",
-        "testpkgtres",
-        "pythonspecific"
-    ]
+    TEST_PACKAGES = ["testpkguno", "testpkgdos", "testpkgtres", "pythonspecific"]
     output_dir = "../../test_data"
 
     def _test_analyze(self, arg_list, pkg_name):
@@ -23,7 +17,7 @@ class TestAnalyzePy:
         res = doppel_analyze.do_everything(args)  # noqa
 
         out_file = os.path.join(self.output_dir, "python_" + pkg_name + ".json")
-        with open(out_file, 'r') as f:
+        with open(out_file, "r") as f:
             result = json.loads(f.read())
             assert isinstance(result, dict)
 
@@ -32,12 +26,16 @@ class TestAnalyzePy:
         for pkg_name in self.TEST_PACKAGES:
             self._test_analyze(
                 [
-                    "--pkg", pkg_name,
-                    "--output_dir", self.output_dir,
-                    "--kwargs-string", "~~kwargs~~",
-                    "--constructor-string", "~~CONSTRUCTOR~~"
+                    "--pkg",
+                    pkg_name,
+                    "--output_dir",
+                    self.output_dir,
+                    "--kwargs-string",
+                    "~~kwargs~~",
+                    "--constructor-string",
+                    "~~CONSTRUCTOR~~",
                 ],
-                pkg_name
+                pkg_name,
             )
 
     def test_verbose(self):
@@ -47,11 +45,15 @@ class TestAnalyzePy:
         for pkg_name in self.TEST_PACKAGES:
             self._test_analyze(
                 [
-                    "--pkg", pkg_name,
-                    "--output_dir", self.output_dir,
-                    "--kwargs-string", "~~kwargs~~",
-                    "--constructor-string", "~~CONSTRUCTOR~~",
-                    "--verbose"
+                    "--pkg",
+                    pkg_name,
+                    "--output_dir",
+                    self.output_dir,
+                    "--kwargs-string",
+                    "~~kwargs~~",
+                    "--constructor-string",
+                    "~~CONSTRUCTOR~~",
+                    "--verbose",
                 ],
-                pkg_name
+                pkg_name,
             )

--- a/.ci/lint-py.sh
+++ b/.ci/lint-py.sh
@@ -4,7 +4,7 @@
 #     Lint python code in a directory for style
 #     problems
 # [usage]
-#     ./.ci/lint_py.sh $(pwd)
+#     ./.ci/lint-py.sh $(pwd)
 
 SOURCE_DIR=${1}
 
@@ -14,30 +14,69 @@ echo ""
 echo "Checking code for python style problems..."
 echo ""
     
-    echo "checking code style with black"
+    echo ""
+    echo "###############"
+    echo "#    black    #"
+    echo "###############"
+    echo ""
     black \
         --line-length ${MAX_LINE_LENGTH} \
-        .
+        --check \
+        --diff \
+        ${SOURCE_DIR} \
     || exit  -1
 
-    echo "running pycodestyle checks"
-    pycodestyle \
-        --show-pep8 \
-        --show-source \
-        --verbose \
-        ${SOURCE_DIR} \
-    || exit -1
-
-    echo "running flake8 checks"
+    echo ""
+    echo "###############"
+    echo "#   flake8    #"
+    echo "###############"
+    echo ""
     flake8 \
         --max-line-length ${MAX_LINE_LENGTH} \
         ${SOURCE_DIR} \
     || exit -1
 
-    echo "running mypy checks"
+    echo ""
+    echo "###############"
+    echo "#   pylint    #"
+    echo "###############"
+    echo ""
+    #
+    # disables:
+    #     * C0103: Variable doesn't conform to snake_case
+    #     * E1120: No value for argument in function call
+    #     * R0801: Similar lines in 2 files
+    #     * R0903: Too few public methods
+    #     * R0914: Too many local variable
+    #     * W1202: Use lazy % formatting in logging functions
+    #
+    pushd ${SOURCE_DIR}/doppel
+        pylint \
+            --disable=C0103,E1120,R0801,R0903,R0914,W1202 \
+            . \
+        || exit -1
+    popd
+
+    echo ""
+    echo "###############"
+    echo "# pycodestyle #"
+    echo "###############"
+    echo ""
+    pycodestyle \
+        --show-source \
+        --max-line-length ${MAX_LINE_LENGTH} \
+        --count \
+        ${SOURCE_DIR} \
+    || exit -1
+
+    echo ""
+    echo "###############"
+    echo "#    mypy     #"
+    echo "###############"
+    echo ""
     mypy \
         --ignore-missing-imports \
-        . \
+        ${SOURCE_DIR} \
     || exit  -1
 
 echo ""

--- a/.ci/lint-py.sh
+++ b/.ci/lint-py.sh
@@ -8,10 +8,18 @@
 
 SOURCE_DIR=${1}
 
+MAX_LINE_LENGTH=100
+
 echo ""
 echo "Checking code for python style problems..."
 echo ""
     
+    echo "checking code style with black"
+    black \
+        --line-length ${MAX_LINE_LENGTH} \
+        .
+    || exit  -1
+
     echo "running pycodestyle checks"
     pycodestyle \
         --show-pep8 \
@@ -22,9 +30,15 @@ echo ""
 
     echo "running flake8 checks"
     flake8 \
-        --ignore=E501 \
+        --max-line-length ${MAX_LINE_LENGTH} \
         ${SOURCE_DIR} \
     || exit -1
+
+    echo "running mypy checks"
+    mypy \
+        --ignore-missing-imports \
+        . \
+    || exit  -1
 
 echo ""
 echo "Done checking code for style problems."

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -21,9 +21,13 @@ if [[ $TASK == "lint" ]]; then
         r-lintr>=2.0.0
     # Get Python packages for testing
     ${CONDA_DIR}/bin/pip install \
+        --upgrade \
         --user \
+            black \
             flake8 \
-            pycodestyle
+            mypy \
+            pycodestyle \
+            pylint
     ${CI_TOOLS}/lint-py.sh $(pwd)
     Rscript ${CI_TOOLS}/lint-r-code.R $(pwd)
     ${CI_TOOLS}/lint-todo.sh $(pwd)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,12 +14,13 @@
 #
 import os
 import sys
-SOURCE_DIR = os.path.abspath('../')
+
+SOURCE_DIR = os.path.abspath("../")
 sys.path.insert(0, SOURCE_DIR)
 
 # Some strings that are re-used a lot
-_PROJECT_NAME = 'doppel-cli'
-_AUTHOR = 'James Lamb'
+_PROJECT_NAME = "doppel-cli"
+_AUTHOR = "James Lamb"
 
 # -- Project information -----------------------------------------------------
 
@@ -28,7 +29,7 @@ copyright = f"2019, {_AUTHOR}"
 author = _AUTHOR
 
 # The short X.Y version
-with open(os.path.join(SOURCE_DIR, 'doppel', 'VERSION'), 'r') as f:
+with open(os.path.join(SOURCE_DIR, "doppel", "VERSION"), "r") as f:
     version = f.read().strip()
 
 # The full version, including alpha/beta/rc tags
@@ -44,21 +45,21 @@ release = version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.mathjax',
-    'sphinx_autodoc_typehints'
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx_autodoc_typehints",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 master_doc = 'index'
 
@@ -72,11 +73,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [
-    '_build',
-    'Thumbs.db',
-    '.DS_Store'
-]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
@@ -86,7 +83,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -97,7 +94,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -120,15 +117,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -138,18 +132,14 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, f"{_PROJECT_NAME}.tex", f"{_PROJECT_NAME} Documentation",
-     _AUTHOR, 'manual'),
+    (master_doc, f"{_PROJECT_NAME}.tex", f"{_PROJECT_NAME} Documentation", _AUTHOR, "manual"),
 ]
 
 # -- Options for manual page output ------------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, _PROJECT_NAME, f"{_PROJECT_NAME} Documentation",
-     [author], 1)
-]
+man_pages = [(master_doc, _PROJECT_NAME, f"{_PROJECT_NAME} Documentation", [author], 1)]
 
 # -- Options for Texinfo output ----------------------------------------------
 
@@ -157,9 +147,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, _PROJECT_NAME, f"{_PROJECT_NAME} Documentation",
-     author, _PROJECT_NAME, 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        _PROJECT_NAME,
+        f"{_PROJECT_NAME} Documentation",
+        author,
+        _PROJECT_NAME,
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # -- Options for Epub output -------------------------------------------------
@@ -177,11 +173,11 @@ epub_title = project
 # epub_uid = ''
 
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
+epub_exclude_files = ["search.html"]
 
 # -- Extension configuration -------------------------------------------------
 
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {"https://docs.python.org/": None}

--- a/doppel/DoppelTestError.py
+++ b/doppel/DoppelTestError.py
@@ -1,13 +1,17 @@
+"""
+Custom error class for testing errors
+"""
+
 
 class DoppelTestError:
+    """
+    Custom error class used for testing issues.
+
+    :param msg: Error text to print
+    """
 
     def __init__(self, msg: str) -> None:
-        """
-        Custom error class used for testing issues.
-
-        :param msg: Error text to print
-        """
         self.msg = msg
 
     def __str__(self) -> str:
-        return("{}\n".format(self.msg))
+        return "{}\n".format(self.msg)

--- a/doppel/PackageAPI.py
+++ b/doppel/PackageAPI.py
@@ -1,4 +1,5 @@
 import json
+
 from typing import Dict
 from typing import List
 

--- a/doppel/PackageAPI.py
+++ b/doppel/PackageAPI.py
@@ -1,3 +1,7 @@
+"""
+Class for package details.
+"""
+
 import json
 
 from typing import Dict
@@ -8,7 +12,7 @@ def _log_info(msg):
     print(msg)
 
 
-class PackageAPI():
+class PackageAPI:
     """Package API class
 
     This class is used to hold the interface of a given package
@@ -44,60 +48,59 @@ class PackageAPI():
         _log_info("Creating package from {}".format(filename))
 
         # read in output of "analyze.*" script
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             pkg_dict = json.loads(f.read())
 
         # validate
         return cls(pkg_dict)
 
-    def _validate_pkg(self, pkg_dict: dict) -> None:
+    @staticmethod
+    def _validate_pkg(pkg_dict: dict) -> None:
 
         assert isinstance(pkg_dict, dict)
-        assert pkg_dict['name'] is not None
-        assert pkg_dict['language'] is not None
-        assert pkg_dict['functions'] is not None
-        assert pkg_dict['classes'] is not None
-
-        return
+        assert pkg_dict["name"] is not None
+        assert pkg_dict["language"] is not None
+        assert pkg_dict["functions"] is not None
+        assert pkg_dict["classes"] is not None
 
     def name(self) -> str:
         """
         Get the name of the package.
         """
-        return(self.pkg_dict['name'])
+        return self.pkg_dict["name"]
 
     def num_functions(self) -> int:
         """
         Get the number of exported functions in the package.
         """
-        return(len(self.function_names()))
+        return len(self.function_names())
 
     def function_names(self) -> List[str]:
         """
         Get a list with the names of all exported functions
         in the package.
         """
-        return(sorted(list(self.pkg_dict['functions'].keys())))
+        return sorted(list(self.pkg_dict["functions"].keys()))
 
     def functions_with_args(self) -> Dict[str, Dict]:
         """
         Get a dictionary with all exported functions in the package
         and some  details describing them.
         """
-        return(self.pkg_dict['functions'])
+        return self.pkg_dict["functions"]
 
     def num_classes(self) -> int:
         """
         Get the number of exported classes in the package.
         """
-        return(len(self.class_names()))
+        return len(self.class_names())
 
     def class_names(self) -> List[str]:
         """
         Get a list with the names of all exported classes
         in the package.
         """
-        return(sorted(list(self.pkg_dict['classes'].keys())))
+        return sorted(list(self.pkg_dict["classes"].keys()))
 
     def public_methods(self, class_name: str) -> List[str]:
         """
@@ -105,7 +108,7 @@ class PackageAPI():
 
         :param class_name: Name of a class in the package
         """
-        return(sorted(list(self.pkg_dict['classes'][class_name]['public_methods'].keys())))
+        return sorted(list(self.pkg_dict["classes"][class_name]["public_methods"].keys()))
 
     def public_method_args(self, class_name: str, method_name: str) -> List[str]:
         """
@@ -114,4 +117,4 @@ class PackageAPI():
         :param class_name: Name of a class in the package
         :param method-name: Name of the method to get arguments for
         """
-        return(list(self.pkg_dict['classes'][class_name]['public_methods'][method_name]['args']))
+        return list(self.pkg_dict["classes"][class_name]["public_methods"][method_name]["args"])

--- a/doppel/PackageCollection.py
+++ b/doppel/PackageCollection.py
@@ -1,3 +1,8 @@
+"""
+``PackageCollection`` implements methods for comparing
+a list of multiple ``PackageAPI`` objects.
+"""
+
 from typing import Dict
 from typing import List
 from typing import Set
@@ -24,7 +29,7 @@ class PackageCollection:
             assert isinstance(pkg, PackageAPI)
 
         pkg_names = [pkg.name() for pkg in packages]
-        if (len(set(pkg_names)) < len(packages)):
+        if len(set(pkg_names)) < len(packages):
             msg = "All packages provided to PackageCollection must have unique names"
             raise ValueError(msg)
 
@@ -34,7 +39,7 @@ class PackageCollection:
         """
         Get a list of all the package names in this collection.
         """
-        return([p.name() for p in self.pkgs])
+        return [p.name() for p in self.pkgs]
 
     def all_classes(self) -> List[str]:
         """
@@ -44,7 +49,7 @@ class PackageCollection:
         out: Set[str] = set([])
         for pkg in self.pkgs:
             out = out.union(pkg.class_names())
-        return(list(out))
+        return list(out)
 
     def shared_classes(self) -> List[str]:
         """
@@ -55,7 +60,7 @@ class PackageCollection:
         out = set(self.pkgs[0].class_names())
         for pkg in self.pkgs[1:]:
             out = out.intersection(pkg.class_names())
-        return(list(out))
+        return list(out)
 
     def non_shared_classes(self) -> List[str]:
         """
@@ -64,7 +69,7 @@ class PackageCollection:
         """
         all_classes = set(self.all_classes())
         shared_classes = set(self.shared_classes())
-        return(list(all_classes.difference(shared_classes)))
+        return list(all_classes.difference(shared_classes))
 
     def all_functions(self) -> List[str]:
         """
@@ -74,7 +79,7 @@ class PackageCollection:
         out: Set[str] = set([])
         for pkg in self.pkgs:
             out = out.union(pkg.function_names())
-        return(list(out))
+        return list(out)
 
     def shared_functions(self) -> List[str]:
         """
@@ -85,7 +90,7 @@ class PackageCollection:
         out = set(self.pkgs[0].function_names())
         for pkg in self.pkgs[1:]:
             out = out.intersection(pkg.function_names())
-        return(list(out))
+        return list(out)
 
     def non_shared_functions(self) -> List[str]:
         """
@@ -94,7 +99,7 @@ class PackageCollection:
         """
         all_funcs = set(self.all_functions())
         shared_funcs = set(self.shared_functions())
-        return(list(all_funcs.difference(shared_funcs)))
+        return list(all_funcs.difference(shared_funcs))
 
     def shared_methods_by_class(self) -> Dict[str, List[str]]:
         """
@@ -108,4 +113,4 @@ class PackageCollection:
             for pkg in self.pkgs[1:]:
                 methods = methods.intersection(pkg.public_methods(class_name))
             out[class_name] = list(methods)
-        return(out)
+        return out

--- a/doppel/PackageCollection.py
+++ b/doppel/PackageCollection.py
@@ -1,6 +1,8 @@
-from doppel.PackageAPI import PackageAPI
 from typing import Dict
 from typing import List
+from typing import Set
+
+from doppel.PackageAPI import PackageAPI
 
 
 class PackageCollection:
@@ -39,7 +41,7 @@ class PackageCollection:
         List of all classes that exist in at least
         one of the packages.
         """
-        out = set([])
+        out: Set[str] = set([])
         for pkg in self.pkgs:
             out = out.union(pkg.class_names())
         return(list(out))
@@ -69,7 +71,7 @@ class PackageCollection:
         List of all functions that exist in at least
         one of the packages.
         """
-        out = set([])
+        out: Set[str] = set([])
         for pkg in self.pkgs:
             out = out.union(pkg.function_names())
         return(list(out))

--- a/doppel/__init__.py
+++ b/doppel/__init__.py
@@ -1,9 +1,11 @@
-__all__ = [
-    'PackageAPI',
-    'PackageCollection'
-]
+"""
+imports for doppel. Use ``__all__`` to add things
+to the API Reference in the docs in ``docs/``.
+"""
+
+__all__ = ["PackageAPI", "PackageCollection"]
 
 from doppel.PackageAPI import PackageAPI
 from doppel.PackageCollection import PackageCollection
-from doppel.DoppelTestError import DoppelTestError   # noqa
+from doppel.DoppelTestError import DoppelTestError  # noqa
 from doppel.reporters import SimpleReporter  # noqa

--- a/doppel/cli.py
+++ b/doppel/cli.py
@@ -1,6 +1,8 @@
 import click
 import os
+
 from sys import stdout
+
 from doppel.reporters import SimpleReporter
 from doppel.PackageAPI import PackageAPI
 

--- a/doppel/cli.py
+++ b/doppel/cli.py
@@ -1,28 +1,26 @@
-import click
+"""
+Implementation for ``doppel-test``
+"""
+
 import os
 
 from sys import stdout
+
+import click
 
 from doppel.reporters import SimpleReporter
 from doppel.PackageAPI import PackageAPI
 
 
 @click.command()
+@click.option("--files", "-f", default=None, help="Comma-delimited list of doppel output files.")
 @click.option(
-    '--files', '-f',
-    default=None,
-    help="Comma-delimited list of doppel output files."
-)
-@click.option(
-    '--errors-allowed',
+    "--errors-allowed",
     default=0,
-    help="Integer number of errors to allow before returning non-zero exit code. Default is 0."
+    help="Integer number of errors to allow before returning non-zero exit code. Default is 0.",
 )
 @click.option(
-    '--version',
-    default=False,
-    help="Get the current version of doppel-test",
-    is_flag=True
+    "--version", default=False, help="Get the current version of doppel-test", is_flag=True
 )
 def main(files: str, errors_allowed: int, version: bool) -> None:
     """
@@ -40,11 +38,8 @@ def main(files: str, errors_allowed: int, version: bool) -> None:
     :param version: Get the current version of doppel-test.
     """
     if version is True:
-        version_file = os.path.join(
-            os.path.dirname(__file__),
-            'VERSION'
-        )
-        with open(version_file, 'r') as f:
+        version_file = os.path.join(os.path.dirname(__file__), "VERSION")
+        with open(version_file, "r") as f:
             out = f.read()
         stdout.write(out)
         return
@@ -54,7 +49,7 @@ def main(files: str, errors_allowed: int, version: bool) -> None:
 
     print("Loading comparison files")
 
-    f_list = files.split(',')
+    f_list = files.split(",")
 
     # Check if these are legit package objects
     pkgs = [PackageAPI.from_json(f) for f in f_list]

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -1,44 +1,38 @@
-import click
-import pkg_resources
+"""
+Code for ``doppel-describe``. This code calls scripts in ``bin/``:
+
+* ``analyze.py``: describe a Python package
+* ``analyze.R``: describe an R package
+"""
+
 import logging
 import os
 
 from sys import stdout
 
+import click
+import pkg_resources
+
 logger = logging.getLogger()
-logging.basicConfig(
-    format='%(levelname)s [%(asctime)s] %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
-)
+logging.basicConfig(format="%(levelname)s [%(asctime)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 
 
 @click.command()
 @click.option(
-    '--language', '-l',
+    "--language",
+    "-l",
     default=None,
-    help="Programming language. Currently python and R are supported."
+    help="Programming language. Currently python and R are supported.",
+)
+@click.option("--pkg_name", "-p", default=None, help="Name of a package")
+@click.option(
+    "--data-dir", "-d", default=None, help="Path to write output file to.",
 )
 @click.option(
-    '--pkg_name', '-p',
-    default=None,
-    help="Name of a package"
+    "--version", default=False, help="Get the current version of doppel-describe", is_flag=True
 )
 @click.option(
-    '--data-dir', '-d',
-    default=None,
-    help="Path to write output file to.",
-)
-@click.option(
-    '--version',
-    default=False,
-    help="Get the current version of doppel-describe",
-    is_flag=True
-)
-@click.option(
-    '--verbose',
-    is_flag=True,
-    default=False,
-    help="Use this flag to get more detailed logs"
+    "--verbose", is_flag=True, default=False, help="Use this flag to get more detailed logs"
 )
 def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bool) -> None:
     """
@@ -46,11 +40,8 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
     write out a JSON representation of it.
     """
     if version is True:
-        version_file = os.path.join(
-            os.path.dirname(__file__),
-            'VERSION'
-        )
-        with open(version_file, 'r') as f:
+        version_file = os.path.join(os.path.dirname(__file__), "VERSION")
+        with open(version_file, "r") as f:
             out = f.read()
         stdout.write(out)
         return
@@ -79,12 +70,9 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
         raise RuntimeError(msg)
 
     try:
-        files = {
-            'python': 'analyze.py',
-            'r': 'analyze.R'
-        }
+        files = {"python": "analyze.py", "r": "analyze.R"}
         analysis_script = pkg_resources.resource_filename(
-            'doppel', 'bin/{}'.format(files[language])
+            "doppel", "bin/{}".format(files[language])
         )
     except KeyError:
         msg = "doppel does not know how to test {} packages".format(language)
@@ -93,12 +81,15 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
 
     logger.info(analysis_script)
 
-    cmd = '{} --pkg {} --output_dir {} --kwargs-string ~~KWARGS~~ --constructor-string ~~CONSTRUCTOR~~'.format(
-        analysis_script, pkg_name, data_dir
+    cmd = (
+        "{} --pkg {} --output_dir {} "
+        "--kwargs-string ~~KWARGS~~ "
+        "--constructor-string ~~CONSTRUCTOR~~"
     )
+    cmd = cmd.format(analysis_script, pkg_name, data_dir)
 
     if verbose is True:
-        cmd += ' --verbose'
+        cmd += " --verbose"
 
     logger.info("Describing package with command:\n {}".format(cmd))
 

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -2,6 +2,7 @@ import click
 import pkg_resources
 import logging
 import os
+
 from sys import stdout
 
 logger = logging.getLogger()

--- a/doppel/reporters.py
+++ b/doppel/reporters.py
@@ -1,8 +1,10 @@
 import sys
 import doppel
+
 from sys import stdout
 from tabulate import tabulate
 from typing import List
+
 from doppel.PackageAPI import PackageAPI
 from doppel.DoppelTestError import DoppelTestError
 
@@ -48,7 +50,7 @@ class SimpleReporter:
         for pkg in pkgs:
             assert isinstance(pkg, doppel.PackageAPI)
 
-        self.errors = []
+        self.errors: List[DoppelTestError] = []
         self.exists_string = 'yes'
         self.absent_string = 'no'
 

--- a/integration_tests/python_tests/test_analyze.py
+++ b/integration_tests/python_tests/test_analyze.py
@@ -12,15 +12,10 @@ import subprocess
 import uuid
 
 # details that will always be true of doppel-describe output
-EXPECTED_TOP_LEVEL_KEYS = set([
-    "name",
-    "language",
-    "functions",
-    "classes"
-])
+EXPECTED_TOP_LEVEL_KEYS = set(["name", "language", "functions", "classes"])
 NUM_TOP_LEVEL_KEYS = len(EXPECTED_TOP_LEVEL_KEYS)
 
-with open('../../doppel/VERSION', 'r') as f:
+with open("../../doppel/VERSION", "r") as f:
     EXPECTED_VERSION = f.read().strip()
 
 
@@ -32,24 +27,17 @@ def rundescribe():
     # there isn't a clean way to pass in
     # command-line args to test scripts, so
     # using environment variables
-    test_packages = [
-        'testpkguno',
-        'testpkgdos',
-        'testpkgtres',
-        'pythonspecific',
-        'pythonspecific2'
-    ]
+    test_packages = ["testpkguno", "testpkgdos", "testpkgtres", "pythonspecific", "pythonspecific2"]
 
     # Added this abomination because something about
     # os.getenv('TEST_PACKAGE_DIR') was resulting in a None
-    test_data_dir = os.path.abspath('../../test_data')
+    test_data_dir = os.path.abspath("../../test_data")
 
     results = {}
 
     for package_name in test_packages:
         cmd = "doppel-describe --language python -p {} --data-dir {}".format(
-            package_name,
-            test_data_dir
+            package_name, test_data_dir
         )
 
         exit_code = os.system(cmd)
@@ -58,11 +46,8 @@ def rundescribe():
             raise RuntimeError(msg.format(exit_code))
 
         output_file = "python_{}.json".format(package_name)
-        path_to_output_file = os.path.join(
-            test_data_dir,
-            output_file
-        )
-        with open(path_to_output_file, 'r') as f:
+        path_to_output_file = os.path.join(test_data_dir, output_file)
+        with open(path_to_output_file, "r") as f:
             result_json = json.loads(f.read())
 
         results[package_name] = result_json
@@ -79,14 +64,14 @@ class TestVersion:
         """
         doppel-test --version should work
         """
-        version_string = os.popen('doppel-test --version').read().strip()
+        version_string = os.popen("doppel-test --version").read().strip()
         assert version_string == EXPECTED_VERSION
 
     def test_describe_version(self):
         """
         doppel-describe --version should work
         """
-        version_string = os.popen('doppel-describe --version').read().strip()
+        version_string = os.popen("doppel-describe --version").read().strip()
         assert version_string == EXPECTED_VERSION
 
 
@@ -95,15 +80,22 @@ class TestBadDataDir:
     An informative error should be thrown if the
     directory passed to --data-dir does nottexist.
     """
+
     def test_describe_bad_input_dir(self):
-        result = subprocess.run([
-            'doppel-describe',
-            '--language', 'python',
-            '-p', 'testpkguno',
-            '--data-dir', str(uuid.uuid4())
-        ], stderr=subprocess.PIPE)
-        error_text = result.stderr.decode('utf-8')
-        assert bool(re.search('passed to --data-dir does not exist', error_text))
+        result = subprocess.run(
+            [
+                "doppel-describe",
+                "--language",
+                "python",
+                "-p",
+                "testpkguno",
+                "--data-dir",
+                str(uuid.uuid4()),
+            ],
+            stderr=subprocess.PIPE,
+        )
+        error_text = result.stderr.decode("utf-8")
+        assert bool(re.search("passed to --data-dir does not exist", error_text))
 
 
 class TestBasicContract:
@@ -118,7 +110,7 @@ class TestBasicContract:
         The JSON file produced by doppel-describe should have
         only the expected top-level dictionary keys
         """
-        result_json = rundescribe['testpkguno']
+        result_json = rundescribe["testpkguno"]
 
         for top_level_key in EXPECTED_TOP_LEVEL_KEYS:
             assert result_json.get(top_level_key, False)
@@ -128,13 +120,13 @@ class TestBasicContract:
         """
         'name' should be a string
         """
-        assert isinstance(rundescribe['testpkguno']['name'], str)
+        assert isinstance(rundescribe["testpkguno"]["name"], str)
 
     def test_language(self, rundescribe):
         """
         'language' should be 'python'
         """
-        assert rundescribe['testpkguno']['language'] == 'python'
+        assert rundescribe["testpkguno"]["language"] == "python"
 
     def test_functions_block(self, rundescribe):
         """
@@ -145,8 +137,8 @@ class TestBasicContract:
         Nothing other than 'args' should be included in the
         function interface.
         """
-        for func_name, func_interface in rundescribe['testpkguno']['functions'].items():
-            args = func_interface['args']
+        for func_name, func_interface in rundescribe["testpkguno"]["functions"].items():
+            args = func_interface["args"]
             assert isinstance(args, list)
             assert len(func_interface.keys()) == 1
             if len(args) > 0:
@@ -164,12 +156,12 @@ class TestBasicContract:
         method interface and nothing other than 'public_methods'
         should be included in the class interface.
         """
-        for class_name, class_interface in rundescribe['testpkguno']['classes'].items():
+        for class_name, class_interface in rundescribe["testpkguno"]["classes"].items():
 
             assert len(class_interface.keys()) == 1
 
-            for method_name, method_interface in class_interface['public_methods'].items():
-                args = method_interface['args']
+            for method_name, method_interface in class_interface["public_methods"].items():
+                args = method_interface["args"]
                 assert isinstance(args, list)
                 assert len(method_interface.keys()) == 1
                 if len(args) > 0:
@@ -189,13 +181,9 @@ class TestFunctionStuff:
 
         No other stuff should end up in "functions".
         """
-        func_dict = rundescribe['testpkguno']['functions']
+        func_dict = rundescribe["testpkguno"]["functions"]
 
-        expected_functions = [
-            'function_a',
-            'function_b',
-            'function_c'
-        ]
+        expected_functions = ["function_a", "function_b", "function_c"]
 
         for f in expected_functions:
             assert func_dict.get(f, False)
@@ -207,27 +195,23 @@ class TestFunctionStuff:
         Functions without any arguments should get an
         'args' dictionary with an empty list.
         """
-        assert rundescribe['testpkguno']['functions']['function_a']['args'] == []
+        assert rundescribe["testpkguno"]["functions"]["function_a"]["args"] == []
 
     def test_regular_function(self, rundescribe):
         """
         Functions with a mix of actual keyword args
         and '**kwargs' should have the correct signature.
         """
-        expected = {
-            "args": ['x', 'y', '~~KWARGS~~']
-        }
-        assert rundescribe['testpkguno']['functions']['function_b'] == expected
+        expected = {"args": ["x", "y", "~~KWARGS~~"]}
+        assert rundescribe["testpkguno"]["functions"]["function_b"] == expected
 
     def test_kwargs_only_function(self, rundescribe):
         """
         Functions with only '**kwargs' should have
         the correct signature.
         """
-        expected = {
-            "args": ['~~KWARGS~~']
-        }
-        assert rundescribe['testpkguno']['functions']['function_c'] == expected
+        expected = {"args": ["~~KWARGS~~"]}
+        assert rundescribe["testpkguno"]["functions"]["function_c"] == expected
 
 
 class TestClassStuff:
@@ -240,16 +224,9 @@ class TestClassStuff:
         """
         Exported classes should all be found.
         """
-        class_dict = rundescribe['testpkguno']['classes']
+        class_dict = rundescribe["testpkguno"]["classes"]
 
-        expected_classes = [
-            'ClassA',
-            'ClassB',
-            'ClassC',
-            'ClassD',
-            'ClassE',
-            'ClassF'
-        ]
+        expected_classes = ["ClassA", "ClassB", "ClassC", "ClassD", "ClassE", "ClassF"]
 
         for c in expected_classes:
             assert class_dict.get(c, False)
@@ -264,18 +241,13 @@ class TestClassStuff:
         No other stuff should end up underneath classes
         within "classes".
         """
-        class_dict = rundescribe['testpkguno']['classes']
-        expected_methods = [
-            '~~CONSTRUCTOR~~',
-            'anarchy',
-            'banarchy',
-            'canarchy'
-        ]
+        class_dict = rundescribe["testpkguno"]["classes"]
+        expected_methods = ["~~CONSTRUCTOR~~", "anarchy", "banarchy", "canarchy"]
 
         for e in expected_methods:
-            assert class_dict['ClassA']['public_methods'].get(e, False)
+            assert class_dict["ClassA"]["public_methods"].get(e, False)
 
-        assert len(class_dict['ClassA']['public_methods'].keys()) == len(expected_methods)
+        assert len(class_dict["ClassA"]["public_methods"].keys()) == len(expected_methods)
 
     def test_inherited_class_public_methods_found(self, rundescribe):
         """
@@ -287,19 +259,13 @@ class TestClassStuff:
         No other stuff should end up underneath classes
         within "classes".
         """
-        class_dict = rundescribe['testpkguno']['classes']
-        expected_methods = [
-            '~~CONSTRUCTOR~~',
-            'anarchy',
-            'banarchy',
-            'canarchy',
-            'hello_there'
-        ]
+        class_dict = rundescribe["testpkguno"]["classes"]
+        expected_methods = ["~~CONSTRUCTOR~~", "anarchy", "banarchy", "canarchy", "hello_there"]
 
         for e in expected_methods:
-            assert class_dict['ClassB']['public_methods'].get(e, False)
+            assert class_dict["ClassB"]["public_methods"].get(e, False)
 
-        assert len(class_dict['ClassB']['public_methods'].keys()) == len(expected_methods)
+        assert len(class_dict["ClassB"]["public_methods"].keys()) == len(expected_methods)
 
     def test_classmethods_found(self, rundescribe):
         """
@@ -307,7 +273,9 @@ class TestClassStuff:
         documented alongside other public methods in
         a class
         """
-        assert rundescribe['testpkguno']['classes']['ClassC']['public_methods'].get('from_string', False)
+        assert rundescribe["testpkguno"]["classes"]["ClassC"]["public_methods"].get(
+            "from_string", False
+        )
 
     def test_inherited_classmethods_found(self, rundescribe):
         """
@@ -315,37 +283,32 @@ class TestClassStuff:
         should be correctly found and documented
         alongside other public methods in a class
         """
-        assert rundescribe['testpkguno']['classes']['ClassD']['public_methods'].get('from_string', False)
+        assert rundescribe["testpkguno"]["classes"]["ClassD"]["public_methods"].get(
+            "from_string", False
+        )
 
     def test_empty_constructors(self, rundescribe):
         """
         Classes with constructors that have no keyword args
         should be serialized correctly
         """
-        class_dict = rundescribe['testpkguno']['classes']
-        expected_methods = [
-            '~~CONSTRUCTOR~~',
-            'from_string'
-        ]
+        class_dict = rundescribe["testpkguno"]["classes"]
+        expected_methods = ["~~CONSTRUCTOR~~", "from_string"]
 
         for e in expected_methods:
-            assert class_dict['ClassE']['public_methods'].get(e, False)
-
-        # test that things with no kwargs produce "args": [], not "args": {}
-        # expect_true(isTRUE(
-        #    grepl('.+"ClassE".+~~CONSTRUCTOR~~.+"args"\\:\\[\\]', RESULTS[["testpkguno"]][["raw"]])
-        # ))
-        # expect_true(isTRUE(
-        #     grepl('.+"from_string".+~~CONSTRUCTOR~~.+"args"\\:\\[\\]', RESULTS[["testpkguno"]][["raw"]])
-        # ))
+            assert class_dict["ClassE"]["public_methods"].get(e, False)
 
     def test_empty_classes(self, rundescribe):
         """
         Totally empty classes should still have their
         constructors documented
         """
-        assert list(rundescribe['testpkguno']['classes']['ClassF']['public_methods'].keys()) == ['~~CONSTRUCTOR~~']
-        assert rundescribe['testpkguno']['classes']['ClassF']['public_methods']['~~CONSTRUCTOR~~'] == {'args': []}
+        assert list(rundescribe["testpkguno"]["classes"]["ClassF"]["public_methods"].keys()) == [
+            "~~CONSTRUCTOR~~"
+        ]
+        assert rundescribe["testpkguno"]["classes"]["ClassF"]["public_methods"][
+            "~~CONSTRUCTOR~~"
+        ] == {"args": []}
 
 
 class TestFunctionOnly:
@@ -359,7 +322,7 @@ class TestFunctionOnly:
         The JSON file produce by doppel-describe
         should have only the expected top-level dictionary keys
         """
-        result_json = rundescribe['testpkgdos']
+        result_json = rundescribe["testpkgdos"]
 
         for top_level_key in EXPECTED_TOP_LEVEL_KEYS:
             assert result_json.get(top_level_key, None) is not None
@@ -377,7 +340,7 @@ class TestClassOnly:
         The JSON file produce by doppel-describe
         should have only the expected top-level dictionary keys
         """
-        result_json = rundescribe['testpkgtres']
+        result_json = rundescribe["testpkgtres"]
 
         for top_level_key in EXPECTED_TOP_LEVEL_KEYS:
             assert result_json.get(top_level_key, None) is not None
@@ -396,7 +359,7 @@ class TestPythonSpecific:
         The JSON file produce by doppel-describe
         should have only the expected top-level dictionary keys
         """
-        result_json = rundescribe['pythonspecific']
+        result_json = rundescribe["pythonspecific"]
 
         for top_level_key in EXPECTED_TOP_LEVEL_KEYS:
             assert result_json.get(top_level_key, None) is not None
@@ -407,10 +370,10 @@ class TestPythonSpecific:
         analyze.py should correctly handle python submodules and
         should ignore package constant.
         """
-        result_json = rundescribe['pythonspecific']
+        result_json = rundescribe["pythonspecific"]
 
-        assert set(result_json['functions'].keys()) == set(['some_function'])
-        assert set(result_json['classes'].keys()) == set(['SomeClass', 'GreatClass', 'MinWrapper'])
+        assert set(result_json["functions"].keys()) == set(["some_function"])
+        assert set(result_json["classes"].keys()) == set(["SomeClass", "GreatClass", "MinWrapper"])
 
     def test_inner_classes(self, rundescribe):
         """
@@ -418,22 +381,24 @@ class TestPythonSpecific:
         that are included as members of another
         class
         """
-        result_json = rundescribe['pythonspecific']
+        result_json = rundescribe["pythonspecific"]
 
-        assert set(result_json['classes']['GreatClass']['public_methods'].keys()) == set(['do_stuff', 'LilGreatClass', '~~CONSTRUCTOR~~'])
-        lil_args = result_json['classes']['GreatClass']['public_methods']['LilGreatClass']['args']
-        assert set(lil_args) == set(['things', 'stuff'])
+        assert set(result_json["classes"]["GreatClass"]["public_methods"].keys()) == set(
+            ["do_stuff", "LilGreatClass", "~~CONSTRUCTOR~~"]
+        )
+        lil_args = result_json["classes"]["GreatClass"]["public_methods"]["LilGreatClass"]["args"]
+        assert set(lil_args) == set(["things", "stuff"])
 
     def test_builtin_func(self, rundescribe):
         """
         analyze.py should correctly handle the case where a built-in
         like min() has been mapped directly to an exported function.
         """
-        result_json = rundescribe['pythonspecific']
+        result_json = rundescribe["pythonspecific"]
 
         # mapping a builtin with something like wrap_min = min
         # is no ta valid way to "re-export" such a function
-        assert 'wrap_min' not in set(result_json['functions'].keys())
+        assert "wrap_min" not in set(result_json["functions"].keys())
 
     def test_builtin_method(self, rundescribe):
         """
@@ -441,9 +406,9 @@ class TestPythonSpecific:
         like min() has been mapped directly to a public method
         of a class
         """
-        result_json = rundescribe['pythonspecific']
+        result_json = rundescribe["pythonspecific"]
 
-        assert result_json['classes']['MinWrapper']['public_methods']['wrap_min'] == {'args': []}
+        assert result_json["classes"]["MinWrapper"]["public_methods"]["wrap_min"] == {"args": []}
 
 
 class TestWeirdImportStuff:
@@ -459,7 +424,7 @@ class TestWeirdImportStuff:
         The JSON file produce by doppel-describe
         should have only the expected top-level dictionary keys
         """
-        result_json = rundescribe['pythonspecific2']
+        result_json = rundescribe["pythonspecific2"]
 
         for top_level_key in EXPECTED_TOP_LEVEL_KEYS:
             assert result_json.get(top_level_key, None) is not None
@@ -471,33 +436,33 @@ class TestWeirdImportStuff:
         whose names do not start with "_", regardless of what is in
         ``__all__`` in ``__init__.py``.
         """
-        result_json = rundescribe['pythonspecific2']
+        result_json = rundescribe["pythonspecific2"]
 
-        assert set(result_json['functions'].keys()) == set(['create_warning', 'create_warm_things'])
+        assert set(result_json["functions"].keys()) == set(["create_warning", "create_warm_things"])
         # imports from other packages are included if you explicitly
         # wrap them in a def()
-        assert 'create_warm_things' in result_json['functions']
+        assert "create_warm_things" in result_json["functions"]
         # import from other packages are excluded even if you map them to
         # a new name in your package
-        assert 'shmeate_schmarning' not in result_json['functions']
+        assert "shmeate_schmarning" not in result_json["functions"]
         # internal functions
-        assert '_super_secret' not in result_json['functions'].keys()
+        assert "_super_secret" not in result_json["functions"].keys()
         # imported standard lib function
-        assert 'warn' not in result_json['functions'].keys()
+        assert "warn" not in result_json["functions"].keys()
         # imported non-standard-lib function
-        assert 'get' not in result_json['functions'].keys()
+        assert "get" not in result_json["functions"].keys()
         # imports from other packages are ignored even if you rename them
         # or add them to __all__ in __init__.py
-        assert 'custom_post' not in result_json['functions'].keys()
-        assert 'post' not in result_json['functions'].keys()
+        assert "custom_post" not in result_json["functions"].keys()
+        assert "post" not in result_json["functions"].keys()
 
     def test_classes(self, rundescribe):
         """
         analyze.py should not have found any classes in this
         package but should have created the 'classes' section
         """
-        result_json = rundescribe['pythonspecific2']
-        assert result_json['classes'] == {}
+        result_json = rundescribe["pythonspecific2"]
+        assert result_json["classes"] == {}
 
 
 class TestMissingFiles:
@@ -505,48 +470,43 @@ class TestMissingFiles:
     An informative error should be thrown immediately if
     you do not provide any of the required arguments.
     """
+
     def test_describe_no_package(self):
         """
         '-p' should be required
         """
-        result = subprocess.run([
-            'doppel-describe',
-            '--language', 'python',
-            '--data-dir', '../../test_data'
-        ], stderr=subprocess.PIPE)
-        error_text = result.stderr.decode('utf-8')
+        result = subprocess.run(
+            ["doppel-describe", "--language", "python", "--data-dir", "../../test_data"],
+            stderr=subprocess.PIPE,
+        )
+        error_text = result.stderr.decode("utf-8")
         assert bool(re.search('Missing option "--pkg_name"', error_text))
 
     def test_describe_no_language(self):
         """
         '-l' should be required
         """
-        result = subprocess.run([
-            'doppel-describe',
-            '-p', 'argparse',
-            '--data-dir', '../../test_data'
-        ], stderr=subprocess.PIPE)
-        error_text = result.stderr.decode('utf-8')
+        result = subprocess.run(
+            ["doppel-describe", "-p", "argparse", "--data-dir", "../../test_data"],
+            stderr=subprocess.PIPE,
+        )
+        error_text = result.stderr.decode("utf-8")
         assert bool(re.search('Missing option "--language"', error_text))
 
     def test_describe_no_data_dir(self):
         """
         '--data-dir' should be required
         """
-        result = subprocess.run([
-            'doppel-describe',
-            '--pkg_name', 'argparse',
-            '-l', 'python'
-        ], stderr=subprocess.PIPE)
-        error_text = result.stderr.decode('utf-8')
+        result = subprocess.run(
+            ["doppel-describe", "--pkg_name", "argparse", "-l", "python"], stderr=subprocess.PIPE
+        )
+        error_text = result.stderr.decode("utf-8")
         assert bool(re.search('Missing option "--data-dir"', error_text))
 
     def test_no_files(self):
         """
         '--files' should be required
         """
-        result = subprocess.run([
-            'doppel-test',
-        ], stderr=subprocess.PIPE)
-        error_text = result.stderr.decode('utf-8')
+        result = subprocess.run(["doppel-test"], stderr=subprocess.PIPE)
+        error_text = result.stderr.decode("utf-8")
         assert bool(re.search('Missing option "--files"', error_text))

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/SomeException.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/SomeException.py
@@ -1,3 +1,2 @@
-
 class SomeException(Exception):
     pass

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/SomeClass.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/SomeClass.py
@@ -1,9 +1,7 @@
-
 SOME_CONSTANT = 10
 
 
 class SomeClass:
-
     def __init__(self):
         pass
 

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/some_function.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/some_function.py
@@ -1,3 +1,2 @@
-
 def some_function(thing: str, stuff: str):
     print(thing + "|" + stuff)

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/wrap_min.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_one/wrap_min.py
@@ -1,4 +1,3 @@
-
 # used to test the "cannot get signature of builtin" code
 wrap_min = min
 
@@ -6,4 +5,5 @@ wrap_min = min
 class MinWrapper:
     def __init__(self):
         pass
+
     wrap_min = min

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_two/GreatClass.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_two/GreatClass.py
@@ -1,6 +1,4 @@
-
 class GreatClass:
-
     def __init__(self, x):
         self.x = x
 
@@ -8,7 +6,6 @@ class GreatClass:
         pass
 
     class LilGreatClass:
-
         def __init__(self, things, stuff):
             self.things = things
             self.stuff = stuff

--- a/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_two/__init__.py
+++ b/integration_tests/test-packages/python/pythonspecific/pythonspecific/mod_two/__init__.py
@@ -1,6 +1,3 @@
-
-__all__ = [
-    "GreatClass"
-]
+__all__ = ["GreatClass"]
 
 from .GreatClass import GreatClass

--- a/integration_tests/test-packages/python/pythonspecific/setup.py
+++ b/integration_tests/test-packages/python/pythonspecific/setup.py
@@ -2,15 +2,15 @@ from setuptools import setup
 from setuptools import find_packages
 
 setup(
-    name='pythonspecific',
+    name="pythonspecific",
     packages=find_packages(),
     description="""
     Test package used to check Python-specific
     things.
     """,
-    version='0.0.1',
-    maintainer='James Lamb',
-    maintainer_email='jaylamb20@gmail.com',
+    version="0.0.1",
+    maintainer="James Lamb",
+    maintainer_email="jaylamb20@gmail.com",
     install_requires=[],
-    extras_require={}
+    extras_require={},
 )

--- a/integration_tests/test-packages/python/pythonspecific2/pythonspecific2/__init__.py
+++ b/integration_tests/test-packages/python/pythonspecific2/pythonspecific2/__init__.py
@@ -1,7 +1,4 @@
 # flake8: noqa
-__all__ = [
-    'create_warning',
-    'custom_post'
-]
+__all__ = ["create_warning", "custom_post"]
 
 from .module import *

--- a/integration_tests/test-packages/python/pythonspecific2/pythonspecific2/module.py
+++ b/integration_tests/test-packages/python/pythonspecific2/pythonspecific2/module.py
@@ -4,8 +4,8 @@ from requests import post as custom_post  # noqa
 
 
 def create_warning():
-    print('uh oh')
-    warn('not good')
+    print("uh oh")
+    warn("not good")
 
 
 shmeate_schmarning = warn
@@ -16,4 +16,4 @@ def create_warm_things(**kwargs):
 
 
 def _super_secret():
-    print('shhhh')
+    print("shhhh")

--- a/integration_tests/test-packages/python/pythonspecific2/setup.py
+++ b/integration_tests/test-packages/python/pythonspecific2/setup.py
@@ -3,7 +3,5 @@ from setuptools import setup
 
 
 setup(
-    name='pythonspecific2',
-    version='0.0.1',
-    packages=find_packages(),
+    name="pythonspecific2", version="0.0.1", packages=find_packages(),
 )

--- a/integration_tests/test-packages/python/testpkgdos/setup.py
+++ b/integration_tests/test-packages/python/testpkgdos/setup.py
@@ -2,16 +2,16 @@ from setuptools import setup
 from setuptools import find_packages
 
 setup(
-    name='testpkgdos',
+    name="testpkgdos",
     packages=find_packages(),
     description="""
     Second package for testing doppel-cli. This
     is used to test the behavior of doppel-cli on
     a functions-only package.
     """,
-    version='0.0.1',
-    maintainer='James Lamb',
-    maintainer_email='jaylamb20@gmail.com',
+    version="0.0.1",
+    maintainer="James Lamb",
+    maintainer_email="jaylamb20@gmail.com",
     install_requires=[],
-    extras_require={}
+    extras_require={},
 )

--- a/integration_tests/test-packages/python/testpkgdos/testpkgdos/add_numbers.py
+++ b/integration_tests/test-packages/python/testpkgdos/testpkgdos/add_numbers.py
@@ -1,4 +1,3 @@
-
 def add_numbers(x, y):
     """add_numbers"""
     return x + y

--- a/integration_tests/test-packages/python/testpkgtres/setup.py
+++ b/integration_tests/test-packages/python/testpkgtres/setup.py
@@ -2,16 +2,16 @@ from setuptools import setup
 from setuptools import find_packages
 
 setup(
-    name='testpkgtres',
+    name="testpkgtres",
     packages=find_packages(),
     description="""
     Third package for testing doppel-cli. This
     is used to test the behavior of doppel-cli on
     a classes-only package.
     """,
-    version='0.0.1',
-    maintainer='James Lamb',
-    maintainer_email='jaylamb20@gmail.com',
+    version="0.0.1",
+    maintainer="James Lamb",
+    maintainer_email="jaylamb20@gmail.com",
     install_requires=[],
-    extras_require={}
+    extras_require={},
 )

--- a/integration_tests/test-packages/python/testpkgtres/testpkgtres/SomeClass.py
+++ b/integration_tests/test-packages/python/testpkgtres/testpkgtres/SomeClass.py
@@ -1,6 +1,4 @@
-
 class SomeClass:
-
     def __init__(self):
         """
         a class that is classy
@@ -8,4 +6,4 @@ class SomeClass:
         pass
 
     def some_method(self, x):
-        return(x + 5)
+        return x + 5

--- a/integration_tests/test-packages/python/testpkguno/setup.py
+++ b/integration_tests/test-packages/python/testpkguno/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup
 from setuptools import find_packages
 
 setup(
-    name='testpkguno',
+    name="testpkguno",
     packages=find_packages(),
-    description='First package for testing doppel-cli',
-    version='0.0.2',
-    maintainer='James Lamb',
-    maintainer_email='jaylamb20@gmail.com',
+    description="First package for testing doppel-cli",
+    version="0.0.2",
+    maintainer="James Lamb",
+    maintainer_email="jaylamb20@gmail.com",
     install_requires=[],
-    extras_require={}
+    extras_require={},
 )

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/ClassB.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/ClassB.py
@@ -1,9 +1,7 @@
-
 from testpkguno import ClassA
 
 
 class ClassB(ClassA):
-
     def __init__(self, **kwargs):
         pass
 
@@ -11,7 +9,7 @@ class ClassB(ClassA):
     # test that ordering of inheritance is
     # respected
     def banarchy(self, nonsense=True):
-        return(nonsense)
+        return nonsense
 
     def hello_there(self, greeting):
         pass
@@ -20,6 +18,5 @@ class ClassB(ClassA):
 # Adding an internal class to be sure tests catch
 # these suddenly getting picked up by analyze.py
 class _SomeInternalClass:
-
     def __init__(self, x):
         self.x = x

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/ClassC.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/ClassC.py
@@ -1,9 +1,7 @@
-
 class ClassC:
-
     def __init__(self, **kwargs):
         pass
 
     @classmethod
     def from_string(cls, the_string):
-        return(cls(the_string=the_string))
+        return cls(the_string=the_string)

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/ClassD.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/ClassD.py
@@ -1,8 +1,6 @@
-
 from testpkguno import ClassC
 
 
 class ClassD(ClassC):
-
     def __init__(self, x):
         self.x = x

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/ClassE.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/ClassE.py
@@ -1,6 +1,4 @@
-
 class ClassE:
-
     def __init__(self):
         """
         This is ClassE, a class whose constructor has
@@ -11,4 +9,4 @@ class ClassE:
 
     @classmethod
     def from_string(cls):
-        return(cls())
+        return cls()

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/ClassF.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/ClassF.py
@@ -1,6 +1,6 @@
-
 class ClassF:
     """
     This is ClassF, a completely empty class
     """
+
     pass

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/function_a.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/function_a.py
@@ -1,4 +1,3 @@
-
 # Adding these imports to be sure that analyze.py
 # isn't tricked into thinking they belong to this
 # package
@@ -9,7 +8,7 @@ from random import LOG4
 # Adding an internal function to be sure tests catch
 # these suddenly getting picked up by analyze.py
 def _add_5(n):
-    return(n + 5)
+    return n + 5
 
 
 def function_a():

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/function_b.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/function_b.py
@@ -1,3 +1,2 @@
-
 def function_b(x, y, **kwargs):
     return True

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/function_c.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/function_c.py
@@ -1,4 +1,3 @@
-
 from functools import lru_cache
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     maintainer="James Lamb",
     maintainer_email="jaylamb20@gmail.com",
     install_requires=runtime_deps,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     extras_require={
         "docs": documentation_deps,
         "testing": testing_deps,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ testing_deps = [
 setup(
     name='doppel-cli',
     packages=find_packages(),
-    description='An integration testing framework for testing API similarity of software libraries.',
+    description=(
+        "An integration testing framework for testing API similarity "
+        "of software libraries."
+    ),
     long_description=readme,
     long_description_content_type="text/markdown",
     version=version,

--- a/setup.py
+++ b/setup.py
@@ -2,71 +2,54 @@ import os
 from setuptools import setup
 from setuptools import find_packages
 
-with open('README.md', 'r') as f:
+with open("README.md", "r") as f:
     readme = f.read()
 
-with open(os.path.join('doppel', 'VERSION'), 'r') as f:
+with open(os.path.join("doppel", "VERSION"), "r") as f:
     version = f.read().strip()
 
-runtime_deps = [
-    'click',
-    'tabulate'
-]
-documentation_deps = [
-    'sphinx',
-    'sphinx_autodoc_typehints',
-    'sphinx_rtd_theme'
-]
-testing_deps = [
-    'coverage'
-]
+runtime_deps = ["click", "tabulate"]
+documentation_deps = ["sphinx", "sphinx_autodoc_typehints", "sphinx_rtd_theme"]
+testing_deps = ["coverage"]
 
 setup(
-    name='doppel-cli',
+    name="doppel-cli",
     packages=find_packages(),
     description=(
-        "An integration testing framework for testing API similarity "
-        "of software libraries."
+        "An integration testing framework for testing API similarity " "of software libraries."
     ),
     long_description=readme,
     long_description_content_type="text/markdown",
     version=version,
-    url='http://github.com/jameslamb/doppel-cli',
-    license='BSD 3-clause',
-    maintainer='James Lamb',
-    maintainer_email='jaylamb20@gmail.com',
+    url="http://github.com/jameslamb/doppel-cli",
+    license="BSD 3-clause",
+    maintainer="James Lamb",
+    maintainer_email="jaylamb20@gmail.com",
     install_requires=runtime_deps,
-    python_requires='>=3.5',
+    python_requires=">=3.5",
     extras_require={
-        'docs': documentation_deps,
-        'testing': testing_deps,
-        'all': runtime_deps + documentation_deps + testing_deps
+        "docs": documentation_deps,
+        "testing": testing_deps,
+        "all": runtime_deps + documentation_deps + testing_deps,
     },
-    package_data={
-        'doppel': [
-            'bin/analyze.R',
-            'bin/analyze.py',
-            'VERSION',
-            'LICENSE'
-        ]
-    },
+    package_data={"doppel": ["bin/analyze.R", "bin/analyze.py", "VERSION", "LICENSE"]},
     entry_points={
-        'console_scripts': [
-            'doppel-describe = doppel.describe:main',
-            'doppel-test = doppel.cli:main'
+        "console_scripts": [
+            "doppel-describe = doppel.describe:main",
+            "doppel-test = doppel.cli:main",
         ]
     },
-    test_suite='tests',
+    test_suite="tests",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Software Development :: Testing'
-    ]
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Software Development :: Testing",
+    ],
 )

--- a/tests/test_DoppelTestError.py
+++ b/tests/test_DoppelTestError.py
@@ -9,13 +9,7 @@ class TestDoppelTestError(unittest.TestCase):
 
     def test_basic(self):
         e = DoppelTestError("hello I am a message")
-        self.assertEqual(
-            e.msg,
-            "hello I am a message"
-        )
+        self.assertEqual(e.msg, "hello I am a message")
 
         txt = str(e)
-        self.assertEqual(
-            txt,
-            "hello I am a message\n"
-        )
+        self.assertEqual(txt, "hello I am a message\n")

--- a/tests/test_package_api.py
+++ b/tests/test_package_api.py
@@ -2,7 +2,7 @@ import unittest
 import os
 from doppel import PackageAPI
 
-TESTDATA_DIR = os.path.join('tests', 'testdata')
+TESTDATA_DIR = os.path.join("tests", "testdata")
 
 
 class TestPackageAPI(unittest.TestCase):
@@ -11,14 +11,8 @@ class TestPackageAPI(unittest.TestCase):
     one class and one or two functions
     """
 
-    py_pkg_file = os.path.join(
-        TESTDATA_DIR,
-        'python_package1.json'
-    )
-    r_pkg_file = os.path.join(
-        TESTDATA_DIR,
-        'r_package1.json'
-    )
+    py_pkg_file = os.path.join(TESTDATA_DIR, "python_package1.json")
+    r_pkg_file = os.path.join(TESTDATA_DIR, "r_package1.json")
 
     def test_from_json_py(self):
         """
@@ -26,31 +20,15 @@ class TestPackageAPI(unittest.TestCase):
         """
         pkg = PackageAPI.from_json(self.py_pkg_file)
 
-        self.assertEqual(pkg.name(), 'boombap [python]')
+        self.assertEqual(pkg.name(), "boombap [python]")
         self.assertEqual(pkg.num_functions(), 1)
-        self.assertEqual(pkg.function_names(), ['playback'])
-        self.assertEqual(
-            pkg.functions_with_args(),
-            {
-                'playback': {
-                    'args': [
-                        'bpm',
-                        'bass'
-                    ]
-                }
-            }
-        )
+        self.assertEqual(pkg.function_names(), ["playback"])
+        self.assertEqual(pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}})
         self.assertEqual(pkg.num_classes(), 1)
         self.assertEqual(pkg.class_names(), ["LupeFiasco"])
         self.assertEqual(pkg.public_methods("LupeFiasco"), ["coast", "~~CONSTRUCTOR~~"])
-        self.assertEqual(
-            pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"),
-            ["kick", "push"]
-        )
-        self.assertEqual(
-            pkg.public_method_args("LupeFiasco", "coast"),
-            []
-        )
+        self.assertEqual(pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"])
+        self.assertEqual(pkg.public_method_args("LupeFiasco", "coast"), [])
 
     def test_from_json_r(self):
         """
@@ -58,32 +36,13 @@ class TestPackageAPI(unittest.TestCase):
         """
         pkg = PackageAPI.from_json(self.r_pkg_file)
 
-        self.assertEqual(pkg.name(), 'boombap [r]')
+        self.assertEqual(pkg.name(), "boombap [r]")
         self.assertEqual(pkg.num_functions(), 1)
-        self.assertEqual(pkg.function_names(), ['playback'])
-        self.assertEqual(
-            pkg.functions_with_args(),
-            {
-                'playback': {
-                    'args': [
-                        'bpm',
-                        'bass'
-                    ]
-                }
-            }
-        )
+        self.assertEqual(pkg.function_names(), ["playback"])
+        self.assertEqual(pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}})
         self.assertEqual(pkg.num_classes(), 1)
         self.assertEqual(pkg.class_names(), ["LupeFiasco"])
         self.assertEqual(pkg.public_methods("LupeFiasco"), ["coast", "words", "~~CONSTRUCTOR~~"])
-        self.assertEqual(
-            pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"),
-            ["kick", "push"]
-        )
-        self.assertEqual(
-            pkg.public_method_args("LupeFiasco", "coast"),
-            []
-        )
-        self.assertEqual(
-            pkg.public_method_args("LupeFiasco", "words"),
-            ["i_said", "i_never_said"]
-        )
+        self.assertEqual(pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"])
+        self.assertEqual(pkg.public_method_args("LupeFiasco", "coast"), [])
+        self.assertEqual(pkg.public_method_args("LupeFiasco", "words"), ["i_said", "i_never_said"])

--- a/tests/test_package_collection.py
+++ b/tests/test_package_collection.py
@@ -3,26 +3,17 @@ import os
 from doppel import PackageCollection
 from doppel import PackageAPI
 
-TESTDATA_DIR = os.path.join('tests', 'testdata')
+TESTDATA_DIR = os.path.join("tests", "testdata")
 
 
 class TestPackageAPI(unittest.TestCase):
 
-    py_pkg_file = os.path.join(
-        TESTDATA_DIR,
-        'python_package1.json'
-    )
-    r_pkg_file = os.path.join(
-        TESTDATA_DIR,
-        'r_package1.json'
-    )
+    py_pkg_file = os.path.join(TESTDATA_DIR, "python_package1.json")
+    r_pkg_file = os.path.join(TESTDATA_DIR, "r_package1.json")
 
     def setUp(self):
         self.pkg_collection = PackageCollection(
-            packages=[
-                PackageAPI.from_json(self.py_pkg_file),
-                PackageAPI.from_json(self.r_pkg_file)
-            ]
+            packages=[PackageAPI.from_json(self.py_pkg_file), PackageAPI.from_json(self.r_pkg_file)]
         )
 
     def test_all_classes(self):
@@ -30,60 +21,42 @@ class TestPackageAPI(unittest.TestCase):
         PackageCollection.all_classes() should work as expected
         for packages with identical classes
         """
-        self.assertEqual(
-            self.pkg_collection.all_classes(),
-            ["LupeFiasco"]
-        )
+        self.assertEqual(self.pkg_collection.all_classes(), ["LupeFiasco"])
 
     def test_shared_classes(self):
         """
         PackageCollection.shared_classes() should work as expected
         for packages with identical classes
         """
-        self.assertEqual(
-            self.pkg_collection.shared_classes(),
-            ["LupeFiasco"]
-        )
+        self.assertEqual(self.pkg_collection.shared_classes(), ["LupeFiasco"])
 
     def test_non_shared_classes(self):
         """
         PackageCollection.non_shared_classes() should work as expected
         for packages with identical classes.
         """
-        self.assertEqual(
-            self.pkg_collection.non_shared_classes(),
-            []
-        )
+        self.assertEqual(self.pkg_collection.non_shared_classes(), [])
 
     def test_all_functions(self):
         """
         PackageCollection.all_functions() should work as expected
         for packages with some overlapping functions
         """
-        self.assertEqual(
-            self.pkg_collection.all_functions(),
-            ["playback"]
-        )
+        self.assertEqual(self.pkg_collection.all_functions(), ["playback"])
 
     def test_shared_functions(self):
         """
         PackageCollection.shared_functions() should work as expected
         for packages with some overlapping functions
         """
-        self.assertEqual(
-            self.pkg_collection.shared_functions(),
-            ["playback"]
-        )
+        self.assertEqual(self.pkg_collection.shared_functions(), ["playback"])
 
     def test_non_shared_functions(self):
         """
         PackageCollection.non_shared_functions() should work as expected
         for packages with some overlapping functions
         """
-        self.assertEqual(
-            self.pkg_collection.non_shared_functions(),
-            []
-        )
+        self.assertEqual(self.pkg_collection.non_shared_functions(), [])
 
     def test_shared_methods_by_class(self):
         """
@@ -93,10 +66,7 @@ class TestPackageAPI(unittest.TestCase):
         """
         shared = self.pkg_collection.shared_methods_by_class()
         self.assertEqual(list(shared.keys()), ["LupeFiasco"])
-        self.assertEqual(
-            sorted(shared["LupeFiasco"]),
-            sorted(["~~CONSTRUCTOR~~", "coast"])
-        )
+        self.assertEqual(sorted(shared["LupeFiasco"]), sorted(["~~CONSTRUCTOR~~", "coast"]))
 
     def test_same_names(self):
         """
@@ -109,7 +79,7 @@ class TestPackageAPI(unittest.TestCase):
             lambda: PackageCollection(
                 packages=[
                     PackageAPI.from_json(self.py_pkg_file),
-                    PackageAPI.from_json(self.py_pkg_file)
+                    PackageAPI.from_json(self.py_pkg_file),
                 ]
-            )
+            ),
         )

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -14,113 +14,80 @@ BASE_PACKAGE: Dict[str, Any] = {
     "name": "pkg1",
     "language": "python",
     "functions": {
-        "playback": {
-            "args": [
-                "bpm",
-                "bass"
-            ]
-        },
-        "reverse": {
-            "args": [
-                "x",
-                "y",
-                "z"
-            ]
-        },
-        "split_channels": {
-            "args": [
-                "keep_list",
-                "exclude_list"
-            ]
-        }
+        "playback": {"args": ["bpm", "bass"]},
+        "reverse": {"args": ["x", "y", "z"]},
+        "split_channels": {"args": ["keep_list", "exclude_list"]},
     },
-    "classes": {}
+    "classes": {},
 }
 
 BASE_PACKAGE2 = copy.deepcopy(BASE_PACKAGE)
-BASE_PACKAGE2['name'] = 'pkg2'
+BASE_PACKAGE2["name"] = "pkg2"
 
 # testing different function stuff
 PACKAGE_WITH_DIFFERENT_ARG_NUMBER = copy.deepcopy(BASE_PACKAGE)
-PACKAGE_WITH_DIFFERENT_ARG_NUMBER['name'] = 'pkg2'
-PACKAGE_WITH_DIFFERENT_ARG_NUMBER['functions']['playback']['args'].append('other')
+PACKAGE_WITH_DIFFERENT_ARG_NUMBER["name"] = "pkg2"
+PACKAGE_WITH_DIFFERENT_ARG_NUMBER["functions"]["playback"]["args"].append("other")
 
 PACKAGE_WITH_DIFFERENT_ARGS = copy.deepcopy(BASE_PACKAGE)
-PACKAGE_WITH_DIFFERENT_ARGS['name'] = 'pkg2'
-PACKAGE_WITH_DIFFERENT_ARGS['functions']['playback']['args'] = ['bass', 'beats_per_minute']
+PACKAGE_WITH_DIFFERENT_ARGS["name"] = "pkg2"
+PACKAGE_WITH_DIFFERENT_ARGS["functions"]["playback"]["args"] = ["bass", "beats_per_minute"]
 
 PACKAGE_WITH_DIFFERENT_ARG_ORDER = copy.deepcopy(BASE_PACKAGE)
-PACKAGE_WITH_DIFFERENT_ARG_ORDER['name'] = 'pkg2'
-PACKAGE_WITH_DIFFERENT_ARG_ORDER['functions']['playback']['args'] = ['bass', 'bpm']
+PACKAGE_WITH_DIFFERENT_ARG_ORDER["name"] = "pkg2"
+PACKAGE_WITH_DIFFERENT_ARG_ORDER["functions"]["playback"]["args"] = ["bass", "bpm"]
 
 # testing different public method stuff
 BASE_PACKAGE_WITH_CLASSES = copy.deepcopy(BASE_PACKAGE)
-BASE_PACKAGE_WITH_CLASSES['classes'] = {
-    'WaleFolarin': {
-        'public_methods': {
-            '~~CONSTRUCTOR~~': {
-                'args': [
-                    'x',
-                    'y',
-                    'z'
-                ]
-            },
-            'no_days_off': {
-                'args': [
-                    'days_to_take',
-                    'songs_to_record'
-                ]
-            }
+BASE_PACKAGE_WITH_CLASSES["classes"] = {
+    "WaleFolarin": {
+        "public_methods": {
+            "~~CONSTRUCTOR~~": {"args": ["x", "y", "z"]},
+            "no_days_off": {"args": ["days_to_take", "songs_to_record"]},
         }
     }
 }
 
 PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
-PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER['name'] = 'pkg2'
-PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER['classes']['WaleFolarin']['public_methods']['no_days_off']['args'].append('about_nothing')
+PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER["name"] = "pkg2"
+PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER["classes"]["WaleFolarin"]["public_methods"]["no_days_off"][
+    "args"
+].append("about_nothing")
 
 PACKAGE_WITH_DIFFERENT_PM_ARGS = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
-PACKAGE_WITH_DIFFERENT_PM_ARGS['name'] = 'pkg3'
-PACKAGE_WITH_DIFFERENT_PM_ARGS['classes']['WaleFolarin']['public_methods']['no_days_off']['args'] = ['days_to_take', 'outchyea']
+PACKAGE_WITH_DIFFERENT_PM_ARGS["name"] = "pkg3"
+PACKAGE_WITH_DIFFERENT_PM_ARGS["classes"]["WaleFolarin"]["public_methods"]["no_days_off"][
+    "args"
+] = ["days_to_take", "outchyea"]
 
 PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
-PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER['name'] = 'pkg4'
-PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER['classes']['WaleFolarin']['public_methods']['no_days_off']['args'] = ['songs_to_record', 'days_to_take']
+PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER["name"] = "pkg4"
+PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER["classes"]["WaleFolarin"]["public_methods"]["no_days_off"][
+    "args"
+] = ["songs_to_record", "days_to_take"]
 
 # super different
 PACKAGE_SUPER_DIFFERENT = copy.deepcopy(BASE_PACKAGE)
-PACKAGE_SUPER_DIFFERENT['name'] = 'pkg2'
-PACKAGE_SUPER_DIFFERENT['functions']['playback']['args'] = ['stuff', 'things', 'bass']
+PACKAGE_SUPER_DIFFERENT["name"] = "pkg2"
+PACKAGE_SUPER_DIFFERENT["functions"]["playback"]["args"] = ["stuff", "things", "bass"]
 
-PACKAGE_EMPTY = {
-    "name": "empty_pkg",
-    "language": "python",
-    "functions": {},
-    "classes": {}
-}
+PACKAGE_EMPTY = {"name": "empty_pkg", "language": "python", "functions": {}, "classes": {}}
 PACKAGE_EMPTY2 = copy.deepcopy(PACKAGE_EMPTY)
-PACKAGE_EMPTY2['name'] = 'pkg2'
+PACKAGE_EMPTY2["name"] = "pkg2"
 
 
 PACKAGE_BEEFY = copy.deepcopy(BASE_PACKAGE)
 for i in range(5):
     func_name = "function_" + str(i)
-    PACKAGE_BEEFY['functions'][func_name] = {
-        "args": ["x", "y", "z"]
-    }
+    PACKAGE_BEEFY["functions"][func_name] = {"args": ["x", "y", "z"]}
 
     class_name = "class_" + str(i)
-    PACKAGE_BEEFY['classes'][class_name] = {
-        'public_methods': {
-            k: {
-                "args": ["thing", "stuff", "ok"]
-            }
-            for k in ["get", "push", "delete"]
-        }
+    PACKAGE_BEEFY["classes"][class_name] = {
+        "public_methods": {k: {"args": ["thing", "stuff", "ok"]} for k in ["get", "push", "delete"]}
     }
 
 PACKAGE_BEEFY2 = copy.deepcopy(PACKAGE_BEEFY)
-PACKAGE_BEEFY2['name'] = 'pkg2'
+PACKAGE_BEEFY2["name"] = "pkg2"
 
 PACKAGE_DIFFERENT_METHODS_1 = {
     "name": "py_pkg",
@@ -128,31 +95,19 @@ PACKAGE_DIFFERENT_METHODS_1 = {
     "functions": {},
     "classes": {
         "SomeClass": {
-            "public_methods": {
-                "~~CONSTRUCTOR~~": {
-                    "args": []
-                },
-                "write_py": {
-                    "args": ["x", "y"]
-                }
-            }
+            "public_methods": {"~~CONSTRUCTOR~~": {"args": []}, "write_py": {"args": ["x", "y"]}}
         }
-    }
+    },
 }
 PACKAGE_DIFFERENT_METHODS_2: Dict[str, Any] = copy.deepcopy(PACKAGE_DIFFERENT_METHODS_1)
-del PACKAGE_DIFFERENT_METHODS_2['classes']['SomeClass']['public_methods']['write_py']
-PACKAGE_DIFFERENT_METHODS_2['classes']['SomeClass']['public_methods'].update({
-    "write_r": {
-        "args": ["x", "y"]
-    }
-})
-PACKAGE_DIFFERENT_METHODS_2.update({
-    "name": "r_pkg"
-})
+del PACKAGE_DIFFERENT_METHODS_2["classes"]["SomeClass"]["public_methods"]["write_py"]
+PACKAGE_DIFFERENT_METHODS_2["classes"]["SomeClass"]["public_methods"].update(
+    {"write_r": {"args": ["x", "y"]}}
+)
+PACKAGE_DIFFERENT_METHODS_2.update({"name": "r_pkg"})
 
 
 class TestSimpleReporter(unittest.TestCase):
-
     def test_function_arg_number(self):
         """
         SimpleReporter should catch the condition where
@@ -160,23 +115,18 @@ class TestSimpleReporter(unittest.TestCase):
         number of keyword arguments.
         """
         reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(BASE_PACKAGE),
-                PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_NUMBER)
-            ],
-            errors_allowed=100
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_NUMBER)],
+            errors_allowed=100,
         )
         reporter._check_function_args()
         errors = reporter.errors
-        self.assertTrue(
-            len(errors) == 3
+        self.assertTrue(len(errors) == 3)
+        self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
+        expected_message = (
+            "Function 'playback()' exists in all packages but with "
+            "differing number of arguments (2,3)."
         )
-        self.assertTrue(
-            all([isinstance(x, DoppelTestError) for x in errors])
-        )
-        self.assertTrue(
-            errors[0].msg == "Function 'playback()' exists in all packages but with differing number of arguments (2,3)."
-        )
+        self.assertTrue(errors[0].msg == expected_message)
 
     def test_function_args(self):
         """
@@ -186,23 +136,18 @@ class TestSimpleReporter(unittest.TestCase):
         of arguments)
         """
         reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(BASE_PACKAGE),
-                PackageAPI(PACKAGE_WITH_DIFFERENT_ARGS)
-            ],
-            errors_allowed=100
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARGS)],
+            errors_allowed=100,
         )
         reporter._check_function_args()
         errors = reporter.errors
-        self.assertTrue(
-            len(errors) == 2
+        self.assertTrue(len(errors) == 2)
+        self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
+        expected_message = (
+            "Function 'playback()' exists in all packages but some "
+            "arguments are not shared in all implementations."
         )
-        self.assertTrue(
-            all([isinstance(x, DoppelTestError) for x in errors])
-        )
-        self.assertTrue(
-            errors[0].msg == "Function 'playback()' exists in all packages but some arguments are not shared in all implementations."
-        )
+        self.assertTrue(errors[0].msg == expected_message)
 
     def test_function_arg_order(self):
         """
@@ -211,23 +156,18 @@ class TestSimpleReporter(unittest.TestCase):
         both packages but they are in different orders'
         """
         reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(BASE_PACKAGE),
-                PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_ORDER)
-            ],
-            errors_allowed=100
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_ORDER)],
+            errors_allowed=100,
         )
         reporter._check_function_args()
         errors = reporter.errors
-        self.assertTrue(
-            len(errors) == 1
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
+        expected_message = (
+            "Function 'playback()' exists in all packages but with "
+            "differing order of keyword arguments."
         )
-        self.assertTrue(
-            all([isinstance(x, DoppelTestError) for x in errors])
-        )
-        self.assertTrue(
-            errors[0].msg == "Function 'playback()' exists in all packages but with differing order of keyword arguments."
-        )
+        self.assertTrue(errors[0].msg == expected_message)
 
     def test_function_all_wrong(self):
         """
@@ -236,23 +176,16 @@ class TestSimpleReporter(unittest.TestCase):
         and different order.
         """
         reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(BASE_PACKAGE),
-                PackageAPI(PACKAGE_SUPER_DIFFERENT)
-            ],
-            errors_allowed=100
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_SUPER_DIFFERENT)], errors_allowed=100
         )
         reporter._check_function_args()
         errors = reporter.errors
-        self.assertTrue(
-            len(errors) == 3
+        self.assertTrue(len(errors) == 3)
+        self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
+        expected_message = (
+            "Function 'playback()' exists in all packages but " "with differing number of arguments"
         )
-        self.assertTrue(
-            all([isinstance(x, DoppelTestError) for x in errors])
-        )
-        self.assertTrue(
-            errors[0].msg.startswith("Function 'playback()' exists in all packages but with differing number of arguments")
-        )
+        self.assertTrue(errors[0].msg.startswith(expected_message))
 
     def test_identical_functions(self):
         """
@@ -260,17 +193,11 @@ class TestSimpleReporter(unittest.TestCase):
         if the shared function is the same in both packages.
         """
         reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(BASE_PACKAGE),
-                PackageAPI(BASE_PACKAGE2)
-            ],
-            errors_allowed=0
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(BASE_PACKAGE2)], errors_allowed=0
         )
         reporter._check_function_args()
         errors = reporter.errors
-        self.assertTrue(
-            len(errors) == 0
-        )
+        self.assertTrue(len(errors) == 0)
 
     def test_public_method_arg_number(self):
         """
@@ -281,21 +208,19 @@ class TestSimpleReporter(unittest.TestCase):
         reporter = SimpleReporter(
             pkgs=[
                 PackageAPI(BASE_PACKAGE_WITH_CLASSES),
-                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER)
+                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER),
             ],
-            errors_allowed=100
+            errors_allowed=100,
         )
         reporter._check_class_public_method_args()
         errors = reporter.errors
-        self.assertTrue(
-            len(errors) == 3
+        self.assertTrue(len(errors) == 3)
+        self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
+        expected_message = (
+            "Public method 'no_days_off()' on class 'WaleFolarin' "
+            "exists in all packages but with differing number of arguments (2,3)."
         )
-        self.assertTrue(
-            all([isinstance(x, DoppelTestError) for x in errors])
-        )
-        self.assertTrue(
-            errors[0].msg == "Public method 'no_days_off()' on class 'WaleFolarin' exists in all packages but with differing number of arguments (2,3)."
-        )
+        self.assertTrue(errors[0].msg == expected_message)
 
     def test_public_method_args(self):
         """
@@ -307,21 +232,19 @@ class TestSimpleReporter(unittest.TestCase):
         reporter = SimpleReporter(
             pkgs=[
                 PackageAPI(BASE_PACKAGE_WITH_CLASSES),
-                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARGS)
+                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARGS),
             ],
-            errors_allowed=100
+            errors_allowed=100,
         )
         reporter._check_class_public_method_args()
         errors = reporter.errors
-        self.assertTrue(
-            len(errors) == 2
+        self.assertTrue(len(errors) == 2)
+        self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
+        expected_message = (
+            "Public method 'no_days_off()' on class 'WaleFolarin' exists in "
+            "all packages but some arguments are not shared in all implementations."
         )
-        self.assertTrue(
-            all([isinstance(x, DoppelTestError) for x in errors])
-        )
-        self.assertTrue(
-            errors[0].msg == "Public method 'no_days_off()' on class 'WaleFolarin' exists in all packages but some arguments are not shared in all implementations."
-        )
+        self.assertTrue(errors[0].msg == expected_message)
 
     def test_public_method_arg_order(self):
         """
@@ -332,21 +255,19 @@ class TestSimpleReporter(unittest.TestCase):
         reporter = SimpleReporter(
             pkgs=[
                 PackageAPI(BASE_PACKAGE_WITH_CLASSES),
-                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER)
+                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER),
             ],
-            errors_allowed=100
+            errors_allowed=100,
         )
         reporter._check_class_public_method_args()
         errors = reporter.errors
-        self.assertTrue(
-            len(errors) == 1
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
+        expected_message = (
+            "Public method 'no_days_off()' on class 'WaleFolarin' exists "
+            "in all packages but with differing order of keyword arguments."
         )
-        self.assertTrue(
-            all([isinstance(x, DoppelTestError) for x in errors])
-        )
-        self.assertTrue(
-            errors[0].msg == "Public method 'no_days_off()' on class 'WaleFolarin' exists in all packages but with differing order of keyword arguments."
-        )
+        self.assertTrue(errors[0].msg == expected_message)
 
     def test_different_public_methods(self):
         """
@@ -355,22 +276,17 @@ class TestSimpleReporter(unittest.TestCase):
         but with different methods.
         """
         reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(PACKAGE_DIFFERENT_METHODS_1),
-                PackageAPI(PACKAGE_DIFFERENT_METHODS_2)
-            ],
-            errors_allowed=2
+            pkgs=[PackageAPI(PACKAGE_DIFFERENT_METHODS_1), PackageAPI(PACKAGE_DIFFERENT_METHODS_2)],
+            errors_allowed=2,
         )
         reporter._check_class_public_methods()
         errors = reporter.errors
+        self.assertTrue(len(errors) == 2)
+        self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
         self.assertTrue(
-            len(errors) == 2
-        )
-        self.assertTrue(
-            all([isinstance(x, DoppelTestError) for x in errors])
-        )
-        self.assertTrue(
-            errors[0].msg.startswith("Not all implementations of class 'SomeClass' have public method")
+            errors[0].msg.startswith(
+                "Not all implementations of class 'SomeClass' have public method"
+            )
         )
 
     def test_totally_empty(self):
@@ -379,11 +295,7 @@ class TestSimpleReporter(unittest.TestCase):
         are totally empty.
         """
         reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(PACKAGE_EMPTY),
-                PackageAPI(PACKAGE_EMPTY2)
-            ],
-            errors_allowed=0
+            pkgs=[PackageAPI(PACKAGE_EMPTY), PackageAPI(PACKAGE_EMPTY2)], errors_allowed=0
         )
         reporter._check_function_args()
         self.assertTrue(reporter.errors == [])
@@ -393,16 +305,14 @@ class TestSimpleReporter(unittest.TestCase):
         SimpleReporter should run end-to-end without error
         """
         reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(PACKAGE_BEEFY),
-                PackageAPI(PACKAGE_SUPER_DIFFERENT)
-            ],
-            errors_allowed=100
+            pkgs=[PackageAPI(PACKAGE_BEEFY), PackageAPI(PACKAGE_SUPER_DIFFERENT)],
+            errors_allowed=100,
         )
 
         # SimpleReporter has a sys.exit() in it. Mock that out
         def f():
             pass
+
         reporter._respond = f
 
         # check packages
@@ -416,16 +326,13 @@ class TestSimpleReporter(unittest.TestCase):
         on shared classes and functions)
         """
         reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(PACKAGE_BEEFY),
-                PackageAPI(PACKAGE_BEEFY2)
-            ],
-            errors_allowed=100
+            pkgs=[PackageAPI(PACKAGE_BEEFY), PackageAPI(PACKAGE_BEEFY2)], errors_allowed=100
         )
 
         # SimpleReporter has a sys.exit() in it. Mock that out
         def f():
             pass
+
         reporter._respond = f
 
         # check packages
@@ -437,16 +344,12 @@ class TestSimpleReporter(unittest.TestCase):
         SimpleReporter should not return any errors if you
         only use a single package
         """
-        reporter = SimpleReporter(
-            pkgs=[
-                PackageAPI(BASE_PACKAGE_WITH_CLASSES)
-            ],
-            errors_allowed=0
-        )
+        reporter = SimpleReporter(pkgs=[PackageAPI(BASE_PACKAGE_WITH_CLASSES)], errors_allowed=0)
 
         # SimpleReporter has a sys.exit() in it. Mock that out
         def f():
             pass
+
         reporter._respond = f
 
         # check packages
@@ -463,14 +366,15 @@ class TestSimpleReporter(unittest.TestCase):
             pkgs=[
                 PackageAPI(BASE_PACKAGE_WITH_CLASSES),
                 PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER),
-                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER)
+                PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER),
             ],
-            errors_allowed=100
+            errors_allowed=100,
         )
 
         # SimpleReporter has a sys.exit() in it. Mock that out
         def f():
             pass
+
         reporter._respond = f
 
         # check packages
@@ -483,26 +387,32 @@ class TestSimpleReporter(unittest.TestCase):
 
         # at least one should be the number-of-arguments error
         self.assertTrue(
-            any([
-                bool(re.search('differing number of arguments', err.msg))
-                for err in reporter.errors
-            ])
+            any(
+                [
+                    bool(re.search("differing number of arguments", err.msg))
+                    for err in reporter.errors
+                ]
+            )
         )
 
         # at least one should be the some-args-not-shared
         self.assertTrue(
-            any([
-                bool(re.search('some arguments are not shared', err.msg))
-                for err in reporter.errors
-            ])
+            any(
+                [
+                    bool(re.search("some arguments are not shared", err.msg))
+                    for err in reporter.errors
+                ]
+            )
         )
 
         # at least one should be the different-order one
         self.assertTrue(
-            any([
-                bool(re.search('differing order of keyword arguments', err.msg))
-                for err in reporter.errors
-            ])
+            any(
+                [
+                    bool(re.search("differing order of keyword arguments", err.msg))
+                    for err in reporter.errors
+                ]
+            )
         )
 
     def test_works_with_ten_packages(self):
@@ -513,21 +423,19 @@ class TestSimpleReporter(unittest.TestCase):
         pkgs = [
             PackageAPI(BASE_PACKAGE_WITH_CLASSES),
             PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER),
-            PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER)
+            PackageAPI(PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER),
         ]
         for i in range(7):
             new_pkg = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
-            new_pkg['name'] = 'test_package_' + str(i)
+            new_pkg["name"] = "test_package_" + str(i)
             pkgs.append(PackageAPI(new_pkg))
 
-        reporter = SimpleReporter(
-            pkgs=pkgs,
-            errors_allowed=100
-        )
+        reporter = SimpleReporter(pkgs=pkgs, errors_allowed=100)
 
         # SimpleReporter has a sys.exit() in it. Mock that out
         def f():
             pass
+
         reporter._respond = f
 
         # check packages
@@ -540,24 +448,30 @@ class TestSimpleReporter(unittest.TestCase):
 
         # at least one should be the number-of-arguments error
         self.assertTrue(
-            any([
-                bool(re.search('differing number of arguments', err.msg))
-                for err in reporter.errors
-            ])
+            any(
+                [
+                    bool(re.search("differing number of arguments", err.msg))
+                    for err in reporter.errors
+                ]
+            )
         )
 
         # at least one should be the some-args-not-shared
         self.assertTrue(
-            any([
-                bool(re.search('some arguments are not shared', err.msg))
-                for err in reporter.errors
-            ])
+            any(
+                [
+                    bool(re.search("some arguments are not shared", err.msg))
+                    for err in reporter.errors
+                ]
+            )
         )
 
         # at least one should be the different-order one
         self.assertTrue(
-            any([
-                bool(re.search('differing order of keyword arguments', err.msg))
-                for err in reporter.errors
-            ])
+            any(
+                [
+                    bool(re.search("differing order of keyword arguments", err.msg))
+                    for err in reporter.errors
+                ]
+            )
         )

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -1,11 +1,16 @@
 import unittest
 import copy
 import re
+
+from typing import Any
+from typing import Dict
+
 from doppel import SimpleReporter
 from doppel import PackageAPI
 from doppel import DoppelTestError
 
-BASE_PACKAGE = {
+
+BASE_PACKAGE: Dict[str, Any] = {
     "name": "pkg1",
     "language": "python",
     "functions": {
@@ -134,7 +139,7 @@ PACKAGE_DIFFERENT_METHODS_1 = {
         }
     }
 }
-PACKAGE_DIFFERENT_METHODS_2 = copy.deepcopy(PACKAGE_DIFFERENT_METHODS_1)
+PACKAGE_DIFFERENT_METHODS_2: Dict[str, Any] = copy.deepcopy(PACKAGE_DIFFERENT_METHODS_1)
 del PACKAGE_DIFFERENT_METHODS_2['classes']['SomeClass']['public_methods']['write_py']
 PACKAGE_DIFFERENT_METHODS_2['classes']['SomeClass']['public_methods'].update({
     "write_r": {

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,0 @@
-[pycodestyle]
-ignore = E501


### PR DESCRIPTION
This PR revamps static analysis of the code.

* adds `mypy` type checking
* reformats the code with `black`
* adds linting with `pylint`

This PR also pushes the floor on the project to Python 3.6, to pick up type hints. Python 3.6 is [3.5 years old at this point](https://www.python.org/downloads/release/python-360/)