### PR TITLE
[ci] updates for new version of black

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -28,7 +28,7 @@ if [[ $TASK == "lint" ]]; then
             mypy \
             pycodestyle \
             pylint
-    ${CI_TOOLS}/lint-py.sh $(pwd)
+    make lint
     Rscript ${CI_TOOLS}/lint-r-code.R $(pwd)
     ${CI_TOOLS}/lint-todo.sh $(pwd)
     exit 0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: format
+format:
+	black --line-length 100 .
+
+.PHONY: lint
+lint:
+	./.ci/lint-py.sh $$(pwd)

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -69,7 +69,7 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
 
     if not os.path.isdir(data_dir):
         msg = "Directory '{}' passed to --data-dir does not exist.".format(data_dir)
-        logger.fatal(msg)
+        logger.fatal(msg)   # type: ignore
         raise RuntimeError(msg)
 
     try:
@@ -79,7 +79,7 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
         )
     except KeyError:
         msg = "doppel does not know how to test {} packages".format(language)
-        logger.fatal(msg)
+        logger.fatal(msg)  # type: ignore
         raise KeyError(msg)
 
     logger.info(analysis_script)
@@ -101,7 +101,7 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
 
     if exit_code != 0:
         msg = "doppel-describe exited with non-zero exit code: {}".format(exit_code)
-        logger.fatal(msg)
+        logger.fatal(msg)  # type: ignore
         raise RuntimeError(msg)
 
     return

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -26,7 +26,10 @@ logging.basicConfig(format="%(levelname)s [%(asctime)s] %(message)s", datefmt="%
 )
 @click.option("--pkg_name", "-p", default=None, help="Name of a package")
 @click.option(
-    "--data-dir", "-d", default=None, help="Path to write output file to.",
+    "--data-dir",
+    "-d",
+    default=None,
+    help="Path to write output file to.",
 )
 @click.option(
     "--version", default=False, help="Get the current version of doppel-describe", is_flag=True

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -69,7 +69,7 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
 
     if not os.path.isdir(data_dir):
         msg = "Directory '{}' passed to --data-dir does not exist.".format(data_dir)
-        logger.fatal(msg)   # type: ignore
+        logger.fatal(msg)  # type: ignore
         raise RuntimeError(msg)
 
     try:

--- a/integration_tests/test-packages/python/pythonspecific2/setup.py
+++ b/integration_tests/test-packages/python/pythonspecific2/setup.py
@@ -3,5 +3,7 @@ from setuptools import setup
 
 
 setup(
-    name="pythonspecific2", version="0.0.1", packages=find_packages(),
+    name="pythonspecific2",
+    version="0.0.1",
+    packages=find_packages(),
 )


### PR DESCRIPTION
`black` recently did a new release. This PR reformats this project's code per that new release.

It also introduces a `Makefile` so you can just do `make format` (to format the code) and `make lint` (to run the linter) without needing to know about the shell scripts.