### PR TITLE
use more specific type hints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up Python
-        uses: conda-incubator/setup-miniconda@v1.7.0
+        uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python_version }}
       - name: Setup and run tests on Linux and macOS

--- a/doppel/PackageAPI.py
+++ b/doppel/PackageAPI.py
@@ -4,11 +4,10 @@ Class for package details.
 
 import json
 
-from typing import Dict
-from typing import List
+from typing import Any, Dict, List
 
 
-def _log_info(msg):
+def _log_info(msg: str) -> None:
     print(msg)
 
 
@@ -22,7 +21,7 @@ class PackageAPI:
 
     """
 
-    def __init__(self, pkg_dict: dict):
+    def __init__(self, pkg_dict: Dict[str, Any]):
         """
         Class containing data that describes a package API
 
@@ -55,7 +54,7 @@ class PackageAPI:
         return cls(pkg_dict)
 
     @staticmethod
-    def _validate_pkg(pkg_dict: dict) -> None:
+    def _validate_pkg(pkg_dict: Dict[str, Any]) -> None:
 
         assert isinstance(pkg_dict, dict)
         assert pkg_dict["name"] is not None
@@ -82,7 +81,7 @@ class PackageAPI:
         """
         return sorted(list(self.pkg_dict["functions"].keys()))
 
-    def functions_with_args(self) -> Dict[str, Dict]:
+    def functions_with_args(self) -> Dict[str, Dict[str, Any]]:
         """
         Get a dictionary with all exported functions in the package
         and some  details describing them.


### PR DESCRIPTION
This also upgrades to the latest version of the `conda-incubator/setup-miniconda` action.