### PR TITLE
[ci] add shellcheck in CI (fixes #197)

### DIFF
--- a/.ci/check-docs.sh
+++ b/.ci/check-docs.sh
@@ -20,7 +20,7 @@ echo ""
         NUM_WARNINGS=$(cat warnings.txt | wc -l)
         if [[ ${NUM_WARNINGS} -ne 0 ]]; then
             echo "Found ${NUM_WARNINGS} issues in Sphinx docs in the docs/ folder";
-            exit ${NUM_WARNINGS};
+            exit "${NUM_WARNINGS}";
         fi
     popd
 

--- a/.ci/check-docs.sh
+++ b/.ci/check-docs.sh
@@ -9,13 +9,13 @@
 # failure is a natural part of life
 set -eou pipefail
 
-SOURCE_DIR=${1}
+SOURCE_DIR="${1}"
 
 echo ""
 echo "Checking docs for problems"
 echo ""
 
-    pushd ${SOURCE_DIR}
+    pushd "${SOURCE_DIR}"
         make html
         NUM_WARNINGS=$(cat warnings.txt | wc -l)
         if [[ ${NUM_WARNINGS} -ne 0 ]]; then

--- a/.ci/install-test-packages.sh
+++ b/.ci/install-test-packages.sh
@@ -18,7 +18,7 @@ echo "installing test R packages..."
 echo ""
 
 if [[ "$OS_NAME" != "windows-latest" ]]; then
-    for pkg in $(ls ${R_TEST_PKG_DIR}); do
+    for pkg in $(ls "${R_TEST_PKG_DIR}"); do
         echo ""
         echo "Installing package '${pkg}'"
         echo ""
@@ -42,7 +42,7 @@ echo ""
 echo "installing test python packages..."
 echo ""
 
-for pkg in $(ls ${PYTHON_TEST_PKG_DIR}); do
+for pkg in $(ls "${PYTHON_TEST_PKG_DIR}"); do
     echo ""
     echo "Installing package '${pkg}'"
     echo ""

--- a/.ci/install-test-packages.sh
+++ b/.ci/install-test-packages.sh
@@ -9,20 +9,20 @@
 # failure is a natural part of life
 set -eo pipefail
 
-TEST_PKG_DIR=$(pwd)/integration_tests/test-packages
-R_TEST_PKG_DIR=${TEST_PKG_DIR}/r
-PYTHON_TEST_PKG_DIR=${TEST_PKG_DIR}/python
+TEST_PKG_DIR="$(pwd)/integration_tests/test-packages"
+R_TEST_PKG_DIR="${TEST_PKG_DIR}/r"
+PYTHON_TEST_PKG_DIR="${TEST_PKG_DIR}/python"
 
 echo ""
 echo "installing test R packages..."
 echo ""
 
-if [[ $OS_NAME != "windows-latest" ]]; then
+if [[ "$OS_NAME" != "windows-latest" ]]; then
     for pkg in $(ls ${R_TEST_PKG_DIR}); do
         echo ""
         echo "Installing package '${pkg}'"
         echo ""
-        pushd ${R_TEST_PKG_DIR}/${pkg}
+        pushd "${R_TEST_PKG_DIR}/${pkg}"
             Rscript --vanilla -e "roxygen2::roxygenize()"
             R CMD INSTALL \
                 --no-docs \
@@ -46,7 +46,7 @@ for pkg in $(ls ${PYTHON_TEST_PKG_DIR}); do
     echo ""
     echo "Installing package '${pkg}'"
     echo ""
-    pushd ${PYTHON_TEST_PKG_DIR}/${pkg}
+    pushd "${PYTHON_TEST_PKG_DIR}/${pkg}"
         python setup.py install --user
     popd
     echo ""

--- a/.ci/lint-py.sh
+++ b/.ci/lint-py.sh
@@ -9,7 +9,7 @@
 # failure is a natural part of life
 set -eou pipefail
 
-SOURCE_DIR=${1}
+SOURCE_DIR="${1}"
 
 MAX_LINE_LENGTH=100
 
@@ -26,8 +26,8 @@ echo ""
         --line-length ${MAX_LINE_LENGTH} \
         --check \
         --diff \
-        ${SOURCE_DIR} \
-    || exit  -1
+        "${SOURCE_DIR}" \
+    || exit 1
 
     echo ""
     echo "###############"
@@ -36,8 +36,8 @@ echo ""
     echo ""
     flake8 \
         --max-line-length ${MAX_LINE_LENGTH} \
-        ${SOURCE_DIR} \
-    || exit -1
+        "${SOURCE_DIR}" \
+    || exit 1
 
     echo ""
     echo "###############"
@@ -53,11 +53,11 @@ echo ""
     #     * R0914: Too many local variable
     #     * W1202: Use lazy % formatting in logging functions
     #
-    pushd ${SOURCE_DIR}/doppel
+    pushd "${SOURCE_DIR}/doppel"
         pylint \
             --disable=C0103,E1120,R0801,R0903,R0914,W1202 \
             . \
-        || exit -1
+        || exit 1
     popd
 
     echo ""
@@ -69,8 +69,8 @@ echo ""
         --show-source \
         --max-line-length ${MAX_LINE_LENGTH} \
         --count \
-        ${SOURCE_DIR} \
-    || exit -1
+        "${SOURCE_DIR}" \
+    || exit 1
 
     echo ""
     echo "###############"
@@ -79,8 +79,8 @@ echo ""
     echo ""
     mypy \
         --ignore-missing-imports \
-        ${SOURCE_DIR} \
-    || exit  -1
+        "${SOURCE_DIR}" \
+    || exit  1
 
 echo ""
 echo "Done checking code for style problems."

--- a/.ci/lint-shell-scripts.sh
+++ b/.ci/lint-shell-scripts.sh
@@ -2,13 +2,17 @@
 
 set -euo pipefail
 
+echo "linting shell scripts with shellcheck"
+
 shell_scripts=$(
     git ls-files \
     | grep -E "\.sh$"
 )
 
+# shellcheck disable=SC2086
 shellcheck \
     --color=never \
     --format=gcc \
-    --exclude=SC2002 \
     $shell_scripts
+
+echo "done running shellcheck"

--- a/.ci/lint-shell-scripts.sh
+++ b/.ci/lint-shell-scripts.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+shell_scripts=$(
+    git ls-files \
+    | grep -E "\.sh$"
+)
+
+shellcheck \
+    --color=never \
+    --format=gcc \
+    --exclude=SC2002 \
+    $shell_scripts

--- a/.ci/lint-todo.sh
+++ b/.ci/lint-todo.sh
@@ -13,7 +13,7 @@ echo "Checking code for TODO comments..."
 echo ""
 todo_count=$(git grep -i -E '#+ *todo' | wc -l)
 echo "TODOs found: ${todo_count}"
-exit ${todo_count}
+exit "${todo_count}"
 
 echo ""
 echo "Done checking code for TODO comments."

--- a/.ci/run-analyze-py-coverage.sh
+++ b/.ci/run-analyze-py-coverage.sh
@@ -11,7 +11,7 @@ set -eou pipefail
 MIN_TEST_COVERAGE=${1}
 
 INTEGRATION_TEST_DIR=$(pwd)/.ci/analyze_py_tests
-mkdir -p $(pwd)/test_data
+mkdir -p "$(pwd)/test_data"
 
 # This is a thing ... need to have a copy of the code
 # near the tests so we can use a relative import to
@@ -27,5 +27,5 @@ pushd "${INTEGRATION_TEST_DIR}"
 
     coverage report \
         -m \
-        --fail-under=${MIN_TEST_COVERAGE}
+        --fail-under="${MIN_TEST_COVERAGE}"
 popd

--- a/.ci/run-analyze-py-coverage.sh
+++ b/.ci/run-analyze-py-coverage.sh
@@ -17,11 +17,11 @@ mkdir -p $(pwd)/test_data
 # near the tests so we can use a relative import to
 # import and call it
 echo "copying analyze.py to a location next to the tests"
-ANALYZE_PY_SCRIPT=$(pwd)/doppel/bin/analyze.py
-ANALYZE_PY_COPY=${INTEGRATION_TEST_DIR}/doppel_analyze.py
-cp ${ANALYZE_PY_SCRIPT} ${ANALYZE_PY_COPY}
+ANALYZE_PY_SCRIPT="$(pwd)/doppel/bin/analyze.py"
+ANALYZE_PY_COPY="${INTEGRATION_TEST_DIR}/doppel_analyze.py"
+cp "${ANALYZE_PY_SCRIPT}" "${ANALYZE_PY_COPY}"
 
-pushd ${INTEGRATION_TEST_DIR}
+pushd "${INTEGRATION_TEST_DIR}"
     pytest \
         --cov
 

--- a/.ci/run-integration-tests.sh
+++ b/.ci/run-integration-tests.sh
@@ -34,8 +34,9 @@ echo ""
 echo ""
 echo "Running R integration tests"
 echo ""
-    
-    export DOPPEL_DESCRIBE_LOC="$(which doppel-describe)"
+
+    DOPPEL_DESCRIBE_LOC="$(which doppel-describe)"
+    export DOPPEL_DESCRIBE_LOC
     pushd "$(pwd)/integration_tests/r_tests"
         Rscript --vanilla -e "testthat::test_dir('.', stop_on_failure = TRUE)"
     popd

--- a/.ci/run-integration-tests.sh
+++ b/.ci/run-integration-tests.sh
@@ -13,15 +13,15 @@
 # failure is a natural part of life
 set -eou pipefail
 
-export TEST_DATA_DIR=${1}
+export TEST_DATA_DIR="${1}"
 
-mkdir -p ${TEST_DATA_DIR}
+mkdir -p "${TEST_DATA_DIR}"
 
 echo ""
 echo "Running python integration tests"
 echo ""
 
-    pushd $(pwd)/integration_tests/python_tests
+    pushd "$(pwd)/integration_tests/python_tests"
         pytest \
             --cache-clear \
             -vv
@@ -35,8 +35,8 @@ echo ""
 echo "Running R integration tests"
 echo ""
     
-    export DOPPEL_DESCRIBE_LOC=$(which doppel-describe)
-    pushd $(pwd)/integration_tests/r_tests
+    export DOPPEL_DESCRIBE_LOC="$(which doppel-describe)"
+    pushd "$(pwd)/integration_tests/r_tests"
         Rscript --vanilla -e "testthat::test_dir('.', stop_on_failure = TRUE)"
     popd
 
@@ -45,14 +45,13 @@ echo "Done running R integration tests"
 echo ""
 
 
-TEST_PKG_DIR=$(pwd)/integration_tests/test-packages
-R_TEST_PKG_DIR=${TEST_PKG_DIR}/r
-PYTHON_TEST_PKG_DIR=${TEST_PKG_DIR}/python
+TEST_PKG_DIR="$(pwd)/integration_tests/test-packages"
+R_TEST_PKG_DIR="${TEST_PKG_DIR}/r"
 
 # All other tests in this file only make sense if
 # the Python and R test packages are equivalent.
 # This block of code down here tests that they are
-for pkg in $(ls ${R_TEST_PKG_DIR}); do
+for pkg in $(ls "${R_TEST_PKG_DIR}"); do
 
     echo ""
     echo "Checking API similarity of package '${pkg}' with doppel-test"

--- a/.ci/run-smoke-tests.sh
+++ b/.ci/run-smoke-tests.sh
@@ -17,7 +17,7 @@
 # failure is a natural part of life
 set -eou pipefail
 
-TEST_DATA_DIR=${1}
+TEST_DATA_DIR="${1}"
 R_TEST_PACKAGE="argparse"
 PYTHON_TEST_PACKAGE="argparse"
 TEST_FILES_TO_COMPARE="${TEST_DATA_DIR}/python_${PYTHON_TEST_PACKAGE}.json,${TEST_DATA_DIR}/r_${R_TEST_PACKAGE}.json"
@@ -26,16 +26,16 @@ echo ""
 echo "Running smoke tests"
 echo ""
 
-    mkdir -p ${TEST_DATA_DIR}
+    mkdir -p "${TEST_DATA_DIR}"
 
     doppel-describe \
         -p ${PYTHON_TEST_PACKAGE} \
         --language python \
-        --data-dir ${TEST_DATA_DIR}
+        --data-dir "${TEST_DATA_DIR}"
     doppel-describe \
         -p ${R_TEST_PACKAGE} \
         --language r \
-        --data-dir ${TEST_DATA_DIR}
+        --data-dir "${TEST_DATA_DIR}"
     doppel-test \
         --files ${TEST_FILES_TO_COMPARE} \
         --errors-allowed 100

--- a/.ci/run-smoke-tests.sh
+++ b/.ci/run-smoke-tests.sh
@@ -37,7 +37,7 @@ echo ""
         --language r \
         --data-dir "${TEST_DATA_DIR}"
     doppel-test \
-        --files ${TEST_FILES_TO_COMPARE} \
+        --files "${TEST_FILES_TO_COMPARE}" \
         --errors-allowed 100
 
 echo ""

--- a/.ci/run-unit-tests.sh
+++ b/.ci/run-unit-tests.sh
@@ -16,7 +16,7 @@ echo "Running unit tests"
 echo ""
 
     coverage run setup.py test
-    coverage report -m --fail-under=${MIN_TEST_COVERAGE}
+    coverage report -m --fail-under="${MIN_TEST_COVERAGE}"
 
 echo ""
 echo "Done running unit tests"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -22,8 +22,7 @@ conda install \
     --quiet \
     r-covr \
     r-argparse \
-    r-futile.logger \
-    shellcheck
+    r-futile.logger
 
 # Get Python packages for testing
 pip install \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -31,6 +31,7 @@ pip install \
     coverage \
     codecov \
     requests \
+    shellcheck \
     sphinx \
     sphinx_autodoc_typehints \
     sphinx_rtd_theme \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -22,7 +22,8 @@ conda install \
     --quiet \
     r-covr \
     r-argparse \
-    r-futile.logger
+    r-futile.logger \
+    shellcheck
 
 # Get Python packages for testing
 pip install \
@@ -31,7 +32,6 @@ pip install \
     coverage \
     codecov \
     requests \
-    shellcheck \
     sphinx \
     sphinx_autodoc_typehints \
     sphinx_rtd_theme \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -9,7 +9,7 @@
 set -eou pipefail
 
 # Set up environment variables
-CI_TOOLS=$(pwd)/.ci
+CI_TOOLS="$(pwd)/.ci"
 
 # Test coverage stuff
 MIN_UNIT_TEST_COVERAGE=100
@@ -18,7 +18,8 @@ MIN_ANALYZE_PY_TEST_COVERAGE=100
 
 if [[ $TASK == "lint" ]]; then
     conda install -c conda-forge \
-        r-lintr>=2.0.0
+        r-lintr>=2.0.0 \
+        shellcheck
     # Get Python packages for testing
     pip install \
         --upgrade \
@@ -29,8 +30,8 @@ if [[ $TASK == "lint" ]]; then
             pycodestyle \
             pylint
     make lint
-    Rscript ${CI_TOOLS}/lint-r-code.R $(pwd)
-    ${CI_TOOLS}/lint-todo.sh
+    Rscript "${CI_TOOLS}/lint-r-code.R" "$(pwd)"
+    "${CI_TOOLS}/lint-todo.sh"
     exit 0
 fi
 
@@ -42,18 +43,18 @@ fi
 
 python setup.py install
 
-${CI_TOOLS}/check-docs.sh $(pwd)/docs
-${CI_TOOLS}/run-unit-tests.sh ${MIN_UNIT_TEST_COVERAGE}
-${CI_TOOLS}/run-smoke-tests.sh $(pwd)/test_data
+"${CI_TOOLS}/check-docs.sh" "$(pwd)/docs"
+"${CI_TOOLS}/run-unit-tests.sh" "${MIN_UNIT_TEST_COVERAGE}"
+"${CI_TOOLS}/run-smoke-tests.sh" "$(pwd)/test_data"
 
-${CI_TOOLS}/install-test-packages.sh
-${CI_TOOLS}/run-integration-tests.sh $(pwd)/test_data
+"${CI_TOOLS}/install-test-packages.sh"
+"${CI_TOOLS}/run-integration-tests.sh" "$(pwd)/test_data"
 
-Rscript --vanilla ${CI_TOOLS}/test-analyze-r-coverage.R \
-    --source-dir $(pwd) \
+Rscript --vanilla "${CI_TOOLS}/test-analyze-r-coverage.R" \
+    --source-dir "$(pwd)" \
     --fail-under ${MIN_ANALYZE_R_TEST_COVERAGE}
 
-${CI_TOOLS}/run-analyze-py-coverage.sh ${MIN_ANALYZE_PY_TEST_COVERAGE}
+"${CI_TOOLS}/run-analyze-py-coverage.sh" "${MIN_ANALYZE_PY_TEST_COVERAGE}"
 
 # If all is good, we did it!
 exit 0

--- a/.ci/update-conda-recipe.sh
+++ b/.ci/update-conda-recipe.sh
@@ -13,26 +13,26 @@ set -eou pipefail
 GITHUB_USER=${1}
 
 DOPPEL_VERSION=$(cat doppel/VERSION)
-TMP_DIR=$(pwd)/conda-install
+TMP_DIR="$(pwd)/conda-install"
 
-pushd ${TMP_DIR}
+pushd "${TMP_DIR}"
 
-    git clone git@github.com:${GITHUB_USER}/doppel-cli-feedstock.git
+    git clone "git@github.com:${GITHUB_USER}/doppel-cli-feedstock.git"
 
     cd doppel-cli-feedstock/recipe
 
     RELEASE_BRANCH="release/v${DOPPEL_VERSION}"
-    git checkout -b ${RELEASE_BRANCH}
+    git checkout -b "${RELEASE_BRANCH}"
     grayskull pypi \
         --maintainers jameslamb \
-        --output $(pwd) \
+        --output "$(pwd)" \
         doppel-cli
 
     mv doppel-cli/meta.yaml .
     rm -r doppel-cli
 
     git commit -m "Updated conda recipe to version ${DOPPEL_VERSION}"
-    git push origin ${RELEASE_BRANCH}
+    git push origin "${RELEASE_BRANCH}"
 
     echo "Done updating recipe! Changes are on branch '${RELEASE_BRANCH}'"
 popd

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,11 @@
+# useless cat
+disable=SC2002
+
+# iterating over ls output is fragile
+disable=SC2045
+
+# Not following: activate was not specified as input
+disable=SC1091
+
+# consider using grep -c instead of grep|wc -l
+disable=SC2126

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,4 @@ format:
 .PHONY: lint
 lint:
 	./.ci/lint-py.sh $$(pwd)
+	./.ci/lint-shell-scripts.sh

--- a/demo.sh
+++ b/demo.sh
@@ -3,26 +3,27 @@
 # failure is a natural part of life
 set -eou pipefail
 
-mkdir -p $(pwd)/test_data
+mkdir -p "$(pwd)/test_data"
 
+# shellcheck disable=SC2043
 for pkg in uptasticsearch; do
 
     # The R package
     doppel-describe \
         -p ${pkg} \
         --language R \
-        --data-dir $(pwd)/test_data
+        --data-dir "$(pwd)/test_data"
 
     # The python package
     doppel-describe \
         -p ${pkg} \
         --language python \
-        --data-dir $(pwd)/test_data
+        --data-dir "$(pwd)/test_data"
 
     # test
     doppel-test \
-        --files $(pwd)/test_data/python_${pkg}.json,$(pwd)/test_data/r_${pkg}.json \
-        | tee ${pkg}.log \
+        --files "$(pwd)/test_data/python_${pkg}.json,$(pwd)/test_data/r_${pkg}.json" \
+        | tee "${pkg}.log" \
         | cat
 
 done

--- a/smoke_tests/all_r_packages.sh
+++ b/smoke_tests/all_r_packages.sh
@@ -6,24 +6,24 @@ set -e
 OUT_DIR=${1:-$(pwd)/smoke_tests/test_data}
 
 # Set up summary file and be sure it's blank
-SUMMARY_FILE=${OUT_DIR}/successful_r_packages.txt
-echo "" > ${SUMMARY_FILE}
+SUMMARY_FILE="${OUT_DIR}/successful_r_packages.txt"
+echo "" > "${SUMMARY_FILE}"
 
 # Function to run doppel-describe
 # [usage]
 #     run_describe ${LANGUAGE} ${OUT_DIR} ${PKG}
 run_describe () {
     doppel-describe \
-        --language ${1} \
-        --data-dir ${2} \
-        -p ${3}
+        --language "${1}" \
+        --data-dir "${2}" \
+        -p "${3}"
 }
 
 R_LIB=$(
     Rscript --vanilla -e "cat(.libPaths()[1])"
 )
-ALL_R_PACKAGES=$(ls ${R_LIB})
-NUM_PACKAGES=$(echo ${ALL_R_PACKAGES} | wc -w)
+ALL_R_PACKAGES=$(ls "${R_LIB}")
+NUM_PACKAGES=$(echo "${ALL_R_PACKAGES}" | wc -w)
 
 echo "You have ${NUM_PACKAGES} R packages installed."
 
@@ -36,9 +36,9 @@ for pkg in ${RANDOM_PACKAGES}; do
 
     echo "Running doppel on package: ${pkg}"
 
-    run_describe R ${OUT_DIR} ${pkg}
+    run_describe R "${OUT_DIR}" "${pkg}"
 
-    echo ${pkg} >> ${SUMMARY_FILE}
+    echo "${pkg}" >> "${SUMMARY_FILE}"
 done
 
-open ${SUMMARY_FILE}
+open "${SUMMARY_FILE}"

--- a/smoke_tests/all_r_packages.sh
+++ b/smoke_tests/all_r_packages.sh
@@ -29,7 +29,7 @@ echo "You have ${NUM_PACKAGES} R packages installed."
 
 # Randomly select packages and start working through them
 RANDOM_PACKAGES=$(
-    echo $ALL_R_PACKAGES | tr ' ' "\n" | sort --sort=random
+    echo "$ALL_R_PACKAGES" | tr ' ' "\n" | sort --sort=random
 )
 
 for pkg in ${RANDOM_PACKAGES}; do

--- a/smoke_tests/run.sh
+++ b/smoke_tests/run.sh
@@ -4,11 +4,11 @@
 set -e
 
 OUT_DIR=${1:-$(pwd)/smoke_tests/test_data}
-PYTHON_PACKAGES="$(cat $(pwd)/smoke_tests/python_packages)"
-R_PACKAGES="$(cat $(pwd)/smoke_tests/r_packages)"
+PYTHON_PACKAGES=$(cat "$(pwd)/smoke_tests/python_packages")
+R_PACKAGES=$(cat "$(pwd)/smoke_tests/r_packages")
 
-SUMMARY_FILE=${OUT_DIR}/results.txt
-echo "" > ${SUMMARY_FILE}
+SUMMARY_FILE="${OUT_DIR}/results.txt"
+echo "" > "${SUMMARY_FILE}"
 
 # Function to run doppel-describe
 # [usage]
@@ -16,25 +16,25 @@ echo "" > ${SUMMARY_FILE}
 run_describe () {
     {
         doppel-describe \
-            --language ${1} \
-            --data-dir ${2} \
-            -p ${3} && \
-        echo "SUCCESS: ${pkg}" >> ${4}
+            --language "${1}" \
+            --data-dir "${2}" \
+            -p "${3}" && \
+        echo "SUCCESS: ${pkg}" >> "${4}"
     } || {
-        echo "FAILURE: ${pkg}" >> ${4}
+        echo "FAILURE: ${pkg}" >> "${4}"
     }
 }
 
-mkdir -p ${OUT_DIR}
+mkdir -p "${OUT_DIR}"
 
-echo "Test results:" > ${SUMMARY_FILE}
+echo "Test results:" > "${SUMMARY_FILE}"
 
 echo "====================="
 echo "== Python packages =="
 echo "====================="
 echo ""
 for pkg in ${PYTHON_PACKAGES}; do
-    run_describe "python" ${OUT_DIR} ${pkg} ${SUMMARY_FILE}
+    run_describe "python" "${OUT_DIR}" "${pkg}" "${SUMMARY_FILE}"
 done
 
 echo ""
@@ -43,15 +43,15 @@ echo "== R packages =="
 echo "================"
 echo ""
 for pkg in ${R_PACKAGES}; do
-    run_describe "r" ${OUT_DIR} ${pkg} ${SUMMARY_FILE}
+    run_describe "r" "${OUT_DIR}" "${pkg}" "${SUMMARY_FILE}"
 done
 
-SUCCESSES=$(cat ${SUMMARY_FILE} | grep SUCCESS | wc -l)
-FAILURES=$(cat ${SUMMARY_FILE} | grep FAILURE | wc -l)
+SUCCESSES=$(cat "${SUMMARY_FILE}" | grep SUCCESS | wc -l)
+FAILURES=$(cat "${SUMMARY_FILE}" | grep FAILURE | wc -l)
 
 echo ""
 echo "Smoke tests complete"
 echo "Successes: ${SUCCESSES}"
 echo "Failures: ${FAILURES}"
 
-open ${SUMMARY_FILE}
+open "${SUMMARY_FILE}"


### PR DESCRIPTION
Fixes #197.

Adds linting on shell scripts using `shellcheck`. See https://github.com/jameslamb/doppel-cli/issues/197#issuecomment-898784509 for a full list of the warnings addressed by this PR and `.shellcheckrc` for the warnings I decided to ignore for now.