### PR TITLE
[ci] fix mypy error about duplicate modules

### DIFF
--- a/.ci/lint-py.sh
+++ b/.ci/lint-py.sh
@@ -79,7 +79,37 @@ echo ""
     echo ""
     mypy \
         --ignore-missing-imports \
-        ${SOURCE_DIR} \
+        ${SOURCE_DIR}/doppel \
+    || exit  -1
+
+    mypy \
+        --ignore-missing-imports \
+        ${SOURCE_DIR}/integration_tests/test-packages/python/pythonspecific \
+    || exit  -1
+
+    mypy \
+        --ignore-missing-imports \
+        ${SOURCE_DIR}/integration_tests/test-packages/python/pythonspecific2 \
+    || exit  -1
+
+    mypy \
+        --ignore-missing-imports \
+        ${SOURCE_DIR}/integration_tests/test-packages/python/testpkguno \
+    || exit  -1
+
+    mypy \
+        --ignore-missing-imports \
+        ${SOURCE_DIR}/integration_tests/test-packages/python/testpkgdos \
+    || exit  -1
+
+    mypy \
+        --ignore-missing-imports \
+        ${SOURCE_DIR}/integration_tests/test-packages/python/testpkgtres \
+    || exit  -1
+
+    mypy \
+        --ignore-missing-imports \
+        ${SOURCE_DIR}/tests \
     || exit  -1
 
 echo ""

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -11,6 +11,7 @@ conda info -a
 conda install \
     -c r \
     --quiet \
+    'r-base>=4.1.0' \
     r-assertthat \
     r-jsonlite \
     r-r6 \

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -9,9 +9,14 @@ conda info -a
 
 # Set up R (gulp)
 conda install \
+    -c conda-forge \
+    --yes \
+    'r-base>=4.1.0'
+
+conda install \
     -c r \
     --quiet \
-    'r-base>=4.1.0' \
+    --yes \
     r-assertthat \
     r-jsonlite \
     r-r6 \
@@ -21,6 +26,7 @@ conda install \
 conda install \
     -c conda-forge \
     --quiet \
+    --yes \
     r-covr \
     r-argparse \
     r-futile.logger

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -18,7 +18,7 @@ MIN_ANALYZE_PY_TEST_COVERAGE=100
 
 if [[ $TASK == "lint" ]]; then
     conda install -c conda-forge \
-        r-lintr>=2.0.0
+        'r-lintr>=2.0.0'
     # Get Python packages for testing
     pip install \
         --upgrade \

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -27,7 +27,10 @@ if [[ $TASK == "lint" ]]; then
             flake8 \
             mypy \
             pycodestyle \
-            pylint
+            pylint \
+            types-requests \
+            types-setuptools \
+            types-tabulate
     make lint
     Rscript ${CI_TOOLS}/lint-r-code.R $(pwd)
     ${CI_TOOLS}/lint-todo.sh

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/ClassB.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/ClassB.py
@@ -1,4 +1,4 @@
-from testpkguno import ClassA
+from .ClassA import ClassA
 
 
 class ClassB(ClassA):

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/ClassD.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/ClassD.py
@@ -1,4 +1,4 @@
-from testpkguno import ClassC
+from .ClassC import ClassC
 
 
 class ClassD(ClassC):

--- a/integration_tests/test-packages/python/testpkguno/testpkguno/function_a.py
+++ b/integration_tests/test-packages/python/testpkguno/testpkguno/function_a.py
@@ -2,7 +2,7 @@
 # isn't tricked into thinking they belong to this
 # package
 import math
-from random import LOG4
+from random import LOG4  # type: ignore
 
 
 # Adding an internal function to be sure tests catch


### PR DESCRIPTION
`make lint` is currently raising the following error using `mypy` 0.910 (the newest version).

> integration_tests/test-packages/python/pythonspecific2/setup.py: error: Duplicate module named "setup" (also at "/home/runner/work/doppel-cli/doppel-cli/integration_tests/test-packages/python/pythonspecific/setup.py")
integration_tests/test-packages/python/pythonspecific2/setup.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
Found 1 error in 1 file (errors prevented further checking)
make: *** [Makefile:7: lint] Error 1
Error: Process completed with exit code 2.

See, for example, https://github.com/jameslamb/doppel-cli/pull/202/checks?check_run_id=3336400834 from #202.

I think is because that code is running `mypy` over the whole repo, and it wasn't designed to lint an entire repo that contains multiple Python packages.

This PR proposes running `mypy` over individual directories one at a time, to avoid that issue.