### PR TITLE
use f-strings for string formatting (fixes #204)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,13 @@ latex_elements = {}
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, f"{_PROJECT_NAME}.tex", f"{_PROJECT_NAME} Documentation", _AUTHOR, "manual"),
+    (
+        master_doc,
+        f"{_PROJECT_NAME}.tex",
+        f"{_PROJECT_NAME} Documentation",
+        _AUTHOR,
+        "manual",
+    ),
 ]
 
 # -- Options for manual page output ------------------------------------------

--- a/doppel/DoppelTestError.py
+++ b/doppel/DoppelTestError.py
@@ -14,4 +14,4 @@ class DoppelTestError:
         self.msg = msg
 
     def __str__(self) -> str:
-        return "{}\n".format(self.msg)
+        return f"{self.msg}\n"

--- a/doppel/PackageAPI.py
+++ b/doppel/PackageAPI.py
@@ -107,7 +107,9 @@ class PackageAPI:
 
         :param class_name: Name of a class in the package
         """
-        return sorted(list(self.pkg_dict["classes"][class_name]["public_methods"].keys()))
+        return sorted(
+            list(self.pkg_dict["classes"][class_name]["public_methods"].keys())
+        )
 
     def public_method_args(self, class_name: str, method_name: str) -> List[str]:
         """
@@ -116,4 +118,6 @@ class PackageAPI:
         :param class_name: Name of a class in the package
         :param method-name: Name of the method to get arguments for
         """
-        return list(self.pkg_dict["classes"][class_name]["public_methods"][method_name]["args"])
+        return list(
+            self.pkg_dict["classes"][class_name]["public_methods"][method_name]["args"]
+        )

--- a/doppel/PackageAPI.py
+++ b/doppel/PackageAPI.py
@@ -44,7 +44,7 @@ class PackageAPI:
             target package's API.
 
         """
-        _log_info("Creating package from {}".format(filename))
+        _log_info(f"Creating package from {filename}")
 
         # read in output of "analyze.*" script
         with open(filename, "r") as f:

--- a/doppel/PackageAPI.py
+++ b/doppel/PackageAPI.py
@@ -107,9 +107,7 @@ class PackageAPI:
 
         :param class_name: Name of a class in the package
         """
-        return sorted(
-            list(self.pkg_dict["classes"][class_name]["public_methods"].keys())
-        )
+        return sorted(list(self.pkg_dict["classes"][class_name]["public_methods"].keys()))
 
     def public_method_args(self, class_name: str, method_name: str) -> List[str]:
         """
@@ -118,6 +116,4 @@ class PackageAPI:
         :param class_name: Name of a class in the package
         :param method-name: Name of the method to get arguments for
         """
-        return list(
-            self.pkg_dict["classes"][class_name]["public_methods"][method_name]["args"]
-        )
+        return list(self.pkg_dict["classes"][class_name]["public_methods"][method_name]["args"])

--- a/doppel/bin/analyze.py
+++ b/doppel/bin/analyze.py
@@ -15,7 +15,9 @@ from typing import List
 
 logger = logging.getLogger()
 logging.basicConfig(
-    format="%(levelname)s [%(asctime)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S", stream=sys.stdout
+    format="%(levelname)s [%(asctime)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    stream=sys.stdout,
 )
 
 
@@ -25,7 +27,9 @@ def parse_args(args):
     parser.add_argument(
         "--output_dir", type=str, default=os.getcwd(), help="Path to write files to"
     )
-    parser.add_argument("--kwargs-string", type=str, help="String value to replace **kwarg")
+    parser.add_argument(
+        "--kwargs-string", type=str, help="String value to replace **kwarg"
+    )
     parser.add_argument(
         "--constructor-string",
         type=str,
@@ -144,7 +148,9 @@ def do_everything(parsed_args):
                 # requests
                 #
                 if obj.__module__.startswith(PKG_NAME):
-                    logger.info("'{}' is a function in this package, adding it".format(obj_name))
+                    logger.info(
+                        "'{}' is a function in this package, adding it".format(obj_name)
+                    )
                     out[FUNCTIONS_KEY][obj_name] = {
                         ARGS_KEY: _get_arg_names(obj, kwargs_string=KWARGS_STRING)
                     }
@@ -162,7 +168,11 @@ def do_everything(parsed_args):
                     is_in_package = bool(re.search(regex, str(obj)))
 
                     if is_in_package:
-                        logger.info("'{}' is a class in this package, adding it".format(obj_name))
+                        logger.info(
+                            "'{}' is a class in this package, adding it".format(
+                                obj_name
+                            )
+                        )
                         out[CLASSES_KEY][obj_name] = {}
                         out[CLASSES_KEY][obj_name][PUBLIC_METHODS_KEY] = {}
 
@@ -209,11 +219,17 @@ def do_everything(parsed_args):
                             # ClassB is basically being used like a public method. Treat it
                             # like that and grab the arguments of its constructor
                             #
-                            is_class_method = str(getattr(class_member, "__self__", None)) == str(
-                                obj
-                            )
-                            if not is_function and not is_constructor and not is_class_method:
-                                init_args = _get_arg_names(class_member.__init__, KWARGS_STRING)
+                            is_class_method = str(
+                                getattr(class_member, "__self__", None)
+                            ) == str(obj)
+                            if (
+                                not is_function
+                                and not is_constructor
+                                and not is_class_method
+                            ):
+                                init_args = _get_arg_names(
+                                    class_member.__init__, KWARGS_STRING
+                                )
                                 is_class_method = (CLASS_KEYWORD in init_args) or (
                                     SELF_KEYWORD in init_args
                                 )
@@ -230,11 +246,15 @@ def do_everything(parsed_args):
                             # this is_function is still here to catch the case where the constructor
                             # wasn't implemented
                             if is_function or is_class_method:
-                                method_args = _get_arg_names(class_member, KWARGS_STRING)
+                                method_args = _get_arg_names(
+                                    class_member, KWARGS_STRING
+                                )
 
                                 # Handle Python "self" conventions
                                 method_args = [
-                                    a for a in method_args if a not in SPECIAL_METHOD_ARGS
+                                    a
+                                    for a in method_args
+                                    if a not in SPECIAL_METHOD_ARGS
                                 ]
 
                                 # If we're dealing with the class constructor, use the
@@ -284,7 +304,9 @@ def do_everything(parsed_args):
                             logger.debug(msg.format(obj.__name__))
                         else:
                             logger.info(
-                                "Module '{}' is in this package, adding it.".format(obj.__name__)
+                                "Module '{}' is in this package, adding it.".format(
+                                    obj.__name__
+                                )
                             )
                             modules_to_parse.append(obj)
 

--- a/doppel/bin/analyze.py
+++ b/doppel/bin/analyze.py
@@ -27,9 +27,7 @@ def parse_args(args):
     parser.add_argument(
         "--output_dir", type=str, default=os.getcwd(), help="Path to write files to"
     )
-    parser.add_argument(
-        "--kwargs-string", type=str, help="String value to replace **kwarg"
-    )
+    parser.add_argument("--kwargs-string", type=str, help="String value to replace **kwarg")
     parser.add_argument(
         "--constructor-string",
         type=str,
@@ -148,9 +146,7 @@ def do_everything(parsed_args):
                 # requests
                 #
                 if obj.__module__.startswith(PKG_NAME):
-                    logger.info(
-                        "'{}' is a function in this package, adding it".format(obj_name)
-                    )
+                    logger.info("'{}' is a function in this package, adding it".format(obj_name))
                     out[FUNCTIONS_KEY][obj_name] = {
                         ARGS_KEY: _get_arg_names(obj, kwargs_string=KWARGS_STRING)
                     }
@@ -168,11 +164,7 @@ def do_everything(parsed_args):
                     is_in_package = bool(re.search(regex, str(obj)))
 
                     if is_in_package:
-                        logger.info(
-                            "'{}' is a class in this package, adding it".format(
-                                obj_name
-                            )
-                        )
+                        logger.info("'{}' is a class in this package, adding it".format(obj_name))
                         out[CLASSES_KEY][obj_name] = {}
                         out[CLASSES_KEY][obj_name][PUBLIC_METHODS_KEY] = {}
 
@@ -219,17 +211,11 @@ def do_everything(parsed_args):
                             # ClassB is basically being used like a public method. Treat it
                             # like that and grab the arguments of its constructor
                             #
-                            is_class_method = str(
-                                getattr(class_member, "__self__", None)
-                            ) == str(obj)
-                            if (
-                                not is_function
-                                and not is_constructor
-                                and not is_class_method
-                            ):
-                                init_args = _get_arg_names(
-                                    class_member.__init__, KWARGS_STRING
-                                )
+                            is_class_method = str(getattr(class_member, "__self__", None)) == str(
+                                obj
+                            )
+                            if not is_function and not is_constructor and not is_class_method:
+                                init_args = _get_arg_names(class_member.__init__, KWARGS_STRING)
                                 is_class_method = (CLASS_KEYWORD in init_args) or (
                                     SELF_KEYWORD in init_args
                                 )
@@ -246,15 +232,11 @@ def do_everything(parsed_args):
                             # this is_function is still here to catch the case where the constructor
                             # wasn't implemented
                             if is_function or is_class_method:
-                                method_args = _get_arg_names(
-                                    class_member, KWARGS_STRING
-                                )
+                                method_args = _get_arg_names(class_member, KWARGS_STRING)
 
                                 # Handle Python "self" conventions
                                 method_args = [
-                                    a
-                                    for a in method_args
-                                    if a not in SPECIAL_METHOD_ARGS
+                                    a for a in method_args if a not in SPECIAL_METHOD_ARGS
                                 ]
 
                                 # If we're dealing with the class constructor, use the
@@ -304,9 +286,7 @@ def do_everything(parsed_args):
                             logger.debug(msg.format(obj.__name__))
                         else:
                             logger.info(
-                                "Module '{}' is in this package, adding it.".format(
-                                    obj.__name__
-                                )
+                                "Module '{}' is in this package, adding it.".format(obj.__name__)
                             )
                             modules_to_parse.append(obj)
 

--- a/doppel/cli.py
+++ b/doppel/cli.py
@@ -13,9 +13,7 @@ from doppel.PackageAPI import PackageAPI
 
 
 @click.command()
-@click.option(
-    "--files", "-f", default=None, help="Comma-delimited list of doppel output files."
-)
+@click.option("--files", "-f", default=None, help="Comma-delimited list of doppel output files.")
 @click.option(
     "--errors-allowed",
     default=0,

--- a/doppel/cli.py
+++ b/doppel/cli.py
@@ -13,14 +13,19 @@ from doppel.PackageAPI import PackageAPI
 
 
 @click.command()
-@click.option("--files", "-f", default=None, help="Comma-delimited list of doppel output files.")
+@click.option(
+    "--files", "-f", default=None, help="Comma-delimited list of doppel output files."
+)
 @click.option(
     "--errors-allowed",
     default=0,
     help="Integer number of errors to allow before returning non-zero exit code. Default is 0.",
 )
 @click.option(
-    "--version", default=False, help="Get the current version of doppel-test", is_flag=True
+    "--version",
+    default=False,
+    help="Get the current version of doppel-test",
+    is_flag=True,
 )
 def main(files: str, errors_allowed: int, version: bool) -> None:
     """

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -14,7 +14,9 @@ import click
 import pkg_resources
 
 logger = logging.getLogger()
-logging.basicConfig(format="%(levelname)s [%(asctime)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+logging.basicConfig(
+    format="%(levelname)s [%(asctime)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+)
 
 
 @click.command()
@@ -32,12 +34,20 @@ logging.basicConfig(format="%(levelname)s [%(asctime)s] %(message)s", datefmt="%
     help="Path to write output file to.",
 )
 @click.option(
-    "--version", default=False, help="Get the current version of doppel-describe", is_flag=True
+    "--version",
+    default=False,
+    help="Get the current version of doppel-describe",
+    is_flag=True,
 )
 @click.option(
-    "--verbose", is_flag=True, default=False, help="Use this flag to get more detailed logs"
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Use this flag to get more detailed logs",
 )
-def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bool) -> None:
+def main(
+    language: str, pkg_name: str, data_dir: str, version: bool, verbose: bool
+) -> None:
     """
     Generate a description of the public API for a software package and
     write out a JSON representation of it.

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -65,20 +65,20 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
         logger.setLevel(logging.INFO)
 
     language = language.lower()
-    logger.info("Testing package {} [{}]".format(pkg_name, language))
+    logger.info(f"Testing package {pkg_name} [{language}]")
 
     if not os.path.isdir(data_dir):
-        msg = "Directory '{}' passed to --data-dir does not exist.".format(data_dir)
+        msg = f"Directory '{data_dir}' passed to --data-dir does not exist."
         logger.fatal(msg)  # type: ignore
         raise RuntimeError(msg)
 
     try:
         files = {"python": "analyze.py", "r": "analyze.R"}
         analysis_script = pkg_resources.resource_filename(
-            "doppel", "bin/{}".format(files[language])
+            "doppel", f"bin/{files[language]}"
         )
     except KeyError:
-        msg = "doppel does not know how to test {} packages".format(language)
+        msg = f"doppel does not know how to test {language} packages"
         logger.fatal(msg)  # type: ignore
         raise KeyError(msg)
 
@@ -94,13 +94,13 @@ def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bo
     if verbose is True:
         cmd += " --verbose"
 
-    logger.info("Describing package with command:\n {}".format(cmd))
+    logger.info(f"Describing package with command:\n {cmd}")
 
     # Invoke the analysis script
     exit_code = os.system(cmd)
 
     if exit_code != 0:
-        msg = "doppel-describe exited with non-zero exit code: {}".format(exit_code)
+        msg = f"doppel-describe exited with non-zero exit code: {exit_code}"
         logger.fatal(msg)  # type: ignore
         raise RuntimeError(msg)
 

--- a/doppel/describe.py
+++ b/doppel/describe.py
@@ -14,9 +14,7 @@ import click
 import pkg_resources
 
 logger = logging.getLogger()
-logging.basicConfig(
-    format="%(levelname)s [%(asctime)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
-)
+logging.basicConfig(format="%(levelname)s [%(asctime)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 
 
 @click.command()
@@ -45,9 +43,7 @@ logging.basicConfig(
     default=False,
     help="Use this flag to get more detailed logs",
 )
-def main(
-    language: str, pkg_name: str, data_dir: str, version: bool, verbose: bool
-) -> None:
+def main(language: str, pkg_name: str, data_dir: str, version: bool, verbose: bool) -> None:
     """
     Generate a description of the public API for a software package and
     write out a JSON representation of it.
@@ -84,9 +80,7 @@ def main(
 
     try:
         files = {"python": "analyze.py", "r": "analyze.R"}
-        analysis_script = pkg_resources.resource_filename(
-            "doppel", f"bin/{files[language]}"
-        )
+        analysis_script = pkg_resources.resource_filename("doppel", f"bin/{files[language]}")
     except KeyError:
         msg = f"doppel does not know how to test {language} packages"
         logger.fatal(msg)  # type: ignore

--- a/doppel/reporters.py
+++ b/doppel/reporters.py
@@ -195,9 +195,7 @@ class SimpleReporter:
         stdout.write("\nFunction Argument Names\n")
         stdout.write("=======================\n")
 
-        func_blocks_by_package = {
-            pkg.name(): pkg.pkg_dict["functions"] for pkg in self.pkgs
-        }
+        func_blocks_by_package = {pkg.name(): pkg.pkg_dict["functions"] for pkg in self.pkgs}
         pkg_names = self.pkg_collection.package_names()
         shared_functions = self.pkg_collection.shared_functions()
 
@@ -216,24 +214,18 @@ class SimpleReporter:
             args = [func_blocks_by_package[p][func_name]["args"] for p in pkg_names]
 
             # check 1: same number of arguments?
-            same_length = all(
-                [len(func_arg_list) == len(args[0]) for func_arg_list in args]
-            )
+            same_length = all([len(func_arg_list) == len(args[0]) for func_arg_list in args])
             if not same_length:
                 error_txt = (
                     "Function '{}()' exists in all packages but with "
                     "differing number of arguments ({})."
                 )
-                error_txt = error_txt.format(
-                    func_name, ",".join([str(len(a)) for a in args])
-                )
+                error_txt = error_txt.format(func_name, ",".join([str(len(a)) for a in args]))
                 self.errors.append(DoppelTestError(error_txt))
                 identical_api = "no"
 
             # check 2: same set of arguments
-            same_args = all(
-                [sorted(func_arg_list) == sorted(args[0]) for func_arg_list in args]
-            )
+            same_args = all([sorted(func_arg_list) == sorted(args[0]) for func_arg_list in args])
             if not same_args:
                 error_txt = (
                     "Function '{}()' exists in all packages but some arguments "
@@ -263,12 +255,10 @@ class SimpleReporter:
             rows.append([func_name, identical_api])
 
         # Report output
-        message = "\n{} of the {} functions shared across all packages have identical signatures\n\n"
-        stdout.write(
-            message.format(
-                len([r for r in rows if r[1] == "yes"]), len(shared_functions)
-            )
+        message = (
+            "\n{} of the {} functions shared across all packages have identical signatures\n\n"
         )
+        stdout.write(message.format(len([r for r in rows if r[1] == "yes"]), len(shared_functions)))
 
         out = _OutputTable(headers=headers, rows=rows)
         out.write()
@@ -298,9 +288,7 @@ class SimpleReporter:
         # Append errors
         if len(set(counts)) > 1:
             error_txt = "Packages have different counts of exported classes! {}"
-            error_txt = error_txt.format(
-                ", ".join([f"{x} ({y})" for x, y in zip(names, counts)])
-            )
+            error_txt = error_txt.format(", ".join([f"{x} ({y})" for x, y in zip(names, counts)]))
             self.errors.append(DoppelTestError(error_txt))
 
         # Print output
@@ -386,9 +374,7 @@ class SimpleReporter:
 
             # If anything is in nonshared methods, add an error
             for method in nonshared_methods:
-                error_txt = (
-                    "Not all implementations of class '{}' have public method '{}()'"
-                )
+                error_txt = "Not all implementations of class '{}' have public method '{}()'"
                 error_txt = error_txt.format(class_name, method)
                 self.errors.append(DoppelTestError(error_txt))
 
@@ -419,14 +405,10 @@ class SimpleReporter:
                 display_name = f"{class_name}.{method_name}()"
 
                 # Generate a list of lists of args
-                args = [
-                    pkg.public_method_args(class_name, method_name) for pkg in self.pkgs
-                ]
+                args = [pkg.public_method_args(class_name, method_name) for pkg in self.pkgs]
 
                 # check 1: same number of arguments?
-                same_length = all(
-                    [len(func_arg_list) == len(args[0]) for func_arg_list in args]
-                )
+                same_length = all([len(func_arg_list) == len(args[0]) for func_arg_list in args])
                 if not same_length:
                     error_txt = (
                         "Public method '{}()' on class '{}' exists in all "

--- a/doppel/reporters.py
+++ b/doppel/reporters.py
@@ -195,7 +195,9 @@ class SimpleReporter:
         stdout.write("\nFunction Argument Names\n")
         stdout.write("=======================\n")
 
-        func_blocks_by_package = {pkg.name(): pkg.pkg_dict["functions"] for pkg in self.pkgs}
+        func_blocks_by_package = {
+            pkg.name(): pkg.pkg_dict["functions"] for pkg in self.pkgs
+        }
         pkg_names = self.pkg_collection.package_names()
         shared_functions = self.pkg_collection.shared_functions()
 
@@ -214,18 +216,24 @@ class SimpleReporter:
             args = [func_blocks_by_package[p][func_name]["args"] for p in pkg_names]
 
             # check 1: same number of arguments?
-            same_length = all([len(func_arg_list) == len(args[0]) for func_arg_list in args])
+            same_length = all(
+                [len(func_arg_list) == len(args[0]) for func_arg_list in args]
+            )
             if not same_length:
                 error_txt = (
                     "Function '{}()' exists in all packages but with "
                     "differing number of arguments ({})."
                 )
-                error_txt = error_txt.format(func_name, ",".join([str(len(a)) for a in args]))
+                error_txt = error_txt.format(
+                    func_name, ",".join([str(len(a)) for a in args])
+                )
                 self.errors.append(DoppelTestError(error_txt))
                 identical_api = "no"
 
             # check 2: same set of arguments
-            same_args = all([sorted(func_arg_list) == sorted(args[0]) for func_arg_list in args])
+            same_args = all(
+                [sorted(func_arg_list) == sorted(args[0]) for func_arg_list in args]
+            )
             if not same_args:
                 error_txt = (
                     "Function '{}()' exists in all packages but some arguments "
@@ -255,10 +263,12 @@ class SimpleReporter:
             rows.append([func_name, identical_api])
 
         # Report output
-        message = (
-            "\n{} of the {} functions shared across all packages have identical signatures\n\n"
+        message = "\n{} of the {} functions shared across all packages have identical signatures\n\n"
+        stdout.write(
+            message.format(
+                len([r for r in rows if r[1] == "yes"]), len(shared_functions)
+            )
         )
-        stdout.write(message.format(len([r for r in rows if r[1] == "yes"]), len(shared_functions)))
 
         out = _OutputTable(headers=headers, rows=rows)
         out.write()
@@ -376,7 +386,9 @@ class SimpleReporter:
 
             # If anything is in nonshared methods, add an error
             for method in nonshared_methods:
-                error_txt = "Not all implementations of class '{}' have public method '{}()'"
+                error_txt = (
+                    "Not all implementations of class '{}' have public method '{}()'"
+                )
                 error_txt = error_txt.format(class_name, method)
                 self.errors.append(DoppelTestError(error_txt))
 
@@ -407,10 +419,14 @@ class SimpleReporter:
                 display_name = f"{class_name}.{method_name}()"
 
                 # Generate a list of lists of args
-                args = [pkg.public_method_args(class_name, method_name) for pkg in self.pkgs]
+                args = [
+                    pkg.public_method_args(class_name, method_name) for pkg in self.pkgs
+                ]
 
                 # check 1: same number of arguments?
-                same_length = all([len(func_arg_list) == len(args[0]) for func_arg_list in args])
+                same_length = all(
+                    [len(func_arg_list) == len(args[0]) for func_arg_list in args]
+                )
                 if not same_length:
                     error_txt = (
                         "Public method '{}()' on class '{}' exists in all "

--- a/doppel/reporters.py
+++ b/doppel/reporters.py
@@ -101,10 +101,10 @@ class SimpleReporter:
         i = 1
         if num_errors > 0:
 
-            stdout.write("\nTest Failures ({})\n".format(num_errors))
+            stdout.write(f"\nTest Failures ({num_errors})\n")
             stdout.write("===================\n")
             for err in self.errors:
-                stdout.write("{}. {}\n".format(i, str(err)))
+                stdout.write(f"{i}. {str(err)}\n")
                 i += 1
 
         # Only throw a non-zero exit code if you had too many errors
@@ -133,7 +133,7 @@ class SimpleReporter:
         if len(set(counts)) > 1:
             error_txt = "Packages have different counts of public functions! {}"
             error_txt = error_txt.format(
-                ", ".join(["{} ({})".format(x, y) for x, y in zip(pkg_names, counts)])
+                ", ".join([f"{x} ({y})" for x, y in zip(pkg_names, counts)])
             )
             self.errors.append(DoppelTestError(error_txt))
 
@@ -181,7 +181,7 @@ class SimpleReporter:
         # Append errors
         if len(non_shared_functions) > 0:
             for func_name in non_shared_functions:
-                error_txt = "Function '{}()' is not exported by all packages".format(func_name)
+                error_txt = f"Function '{func_name}()' is not exported by all packages"
                 self.errors.append(DoppelTestError(error_txt))
 
         # Print output
@@ -289,7 +289,7 @@ class SimpleReporter:
         if len(set(counts)) > 1:
             error_txt = "Packages have different counts of exported classes! {}"
             error_txt = error_txt.format(
-                ", ".join(["{} ({})".format(x, y) for x, y in zip(names, counts)])
+                ", ".join([f"{x} ({y})" for x, y in zip(names, counts)])
             )
             self.errors.append(DoppelTestError(error_txt))
 
@@ -337,7 +337,7 @@ class SimpleReporter:
         # Append errors
         if len(non_shared_classes) > 0:
             for class_name in non_shared_classes:
-                error_txt = "Class '{}' is not exported by all packages".format(class_name)
+                error_txt = f"Class '{class_name}' is not exported by all packages"
                 self.errors.append(DoppelTestError(error_txt))
 
         # Print output
@@ -404,7 +404,7 @@ class SimpleReporter:
 
                 identical_api = "yes"
 
-                display_name = "{}.{}()".format(class_name, method_name)
+                display_name = f"{class_name}.{method_name}()"
 
                 # Generate a list of lists of args
                 args = [pkg.public_method_args(class_name, method_name) for pkg in self.pkgs]

--- a/integration_tests/python_tests/test_analyze.py
+++ b/integration_tests/python_tests/test_analyze.py
@@ -27,7 +27,13 @@ def rundescribe():
     # there isn't a clean way to pass in
     # command-line args to test scripts, so
     # using environment variables
-    test_packages = ["testpkguno", "testpkgdos", "testpkgtres", "pythonspecific", "pythonspecific2"]
+    test_packages = [
+        "testpkguno",
+        "testpkgdos",
+        "testpkgtres",
+        "pythonspecific",
+        "pythonspecific2",
+    ]
 
     # Added this abomination because something about
     # os.getenv('TEST_PACKAGE_DIR') was resulting in a None
@@ -160,7 +166,9 @@ class TestBasicContract:
 
             assert len(class_interface.keys()) == 1
 
-            for method_name, method_interface in class_interface["public_methods"].items():
+            for method_name, method_interface in class_interface[
+                "public_methods"
+            ].items():
                 args = method_interface["args"]
                 assert isinstance(args, list)
                 assert len(method_interface.keys()) == 1
@@ -247,7 +255,9 @@ class TestClassStuff:
         for e in expected_methods:
             assert class_dict["ClassA"]["public_methods"].get(e, False)
 
-        assert len(class_dict["ClassA"]["public_methods"].keys()) == len(expected_methods)
+        assert len(class_dict["ClassA"]["public_methods"].keys()) == len(
+            expected_methods
+        )
 
     def test_inherited_class_public_methods_found(self, rundescribe):
         """
@@ -260,12 +270,20 @@ class TestClassStuff:
         within "classes".
         """
         class_dict = rundescribe["testpkguno"]["classes"]
-        expected_methods = ["~~CONSTRUCTOR~~", "anarchy", "banarchy", "canarchy", "hello_there"]
+        expected_methods = [
+            "~~CONSTRUCTOR~~",
+            "anarchy",
+            "banarchy",
+            "canarchy",
+            "hello_there",
+        ]
 
         for e in expected_methods:
             assert class_dict["ClassB"]["public_methods"].get(e, False)
 
-        assert len(class_dict["ClassB"]["public_methods"].keys()) == len(expected_methods)
+        assert len(class_dict["ClassB"]["public_methods"].keys()) == len(
+            expected_methods
+        )
 
     def test_classmethods_found(self, rundescribe):
         """
@@ -303,9 +321,9 @@ class TestClassStuff:
         Totally empty classes should still have their
         constructors documented
         """
-        assert list(rundescribe["testpkguno"]["classes"]["ClassF"]["public_methods"].keys()) == [
-            "~~CONSTRUCTOR~~"
-        ]
+        assert list(
+            rundescribe["testpkguno"]["classes"]["ClassF"]["public_methods"].keys()
+        ) == ["~~CONSTRUCTOR~~"]
         assert rundescribe["testpkguno"]["classes"]["ClassF"]["public_methods"][
             "~~CONSTRUCTOR~~"
         ] == {"args": []}
@@ -373,7 +391,9 @@ class TestPythonSpecific:
         result_json = rundescribe["pythonspecific"]
 
         assert set(result_json["functions"].keys()) == set(["some_function"])
-        assert set(result_json["classes"].keys()) == set(["SomeClass", "GreatClass", "MinWrapper"])
+        assert set(result_json["classes"].keys()) == set(
+            ["SomeClass", "GreatClass", "MinWrapper"]
+        )
 
     def test_inner_classes(self, rundescribe):
         """
@@ -383,10 +403,12 @@ class TestPythonSpecific:
         """
         result_json = rundescribe["pythonspecific"]
 
-        assert set(result_json["classes"]["GreatClass"]["public_methods"].keys()) == set(
-            ["do_stuff", "LilGreatClass", "~~CONSTRUCTOR~~"]
-        )
-        lil_args = result_json["classes"]["GreatClass"]["public_methods"]["LilGreatClass"]["args"]
+        assert set(
+            result_json["classes"]["GreatClass"]["public_methods"].keys()
+        ) == set(["do_stuff", "LilGreatClass", "~~CONSTRUCTOR~~"])
+        lil_args = result_json["classes"]["GreatClass"]["public_methods"][
+            "LilGreatClass"
+        ]["args"]
         assert set(lil_args) == set(["things", "stuff"])
 
     def test_builtin_func(self, rundescribe):
@@ -408,7 +430,9 @@ class TestPythonSpecific:
         """
         result_json = rundescribe["pythonspecific"]
 
-        assert result_json["classes"]["MinWrapper"]["public_methods"]["wrap_min"] == {"args": []}
+        assert result_json["classes"]["MinWrapper"]["public_methods"]["wrap_min"] == {
+            "args": []
+        }
 
 
 class TestWeirdImportStuff:
@@ -438,7 +462,9 @@ class TestWeirdImportStuff:
         """
         result_json = rundescribe["pythonspecific2"]
 
-        assert set(result_json["functions"].keys()) == set(["create_warning", "create_warm_things"])
+        assert set(result_json["functions"].keys()) == set(
+            ["create_warning", "create_warm_things"]
+        )
         # imports from other packages are included if you explicitly
         # wrap them in a def()
         assert "create_warm_things" in result_json["functions"]
@@ -476,7 +502,13 @@ class TestMissingFiles:
         '-p' should be required
         """
         result = subprocess.run(
-            ["doppel-describe", "--language", "python", "--data-dir", "../../test_data"],
+            [
+                "doppel-describe",
+                "--language",
+                "python",
+                "--data-dir",
+                "../../test_data",
+            ],
             stderr=subprocess.PIPE,
         )
         error_text = result.stderr.decode("utf-8")
@@ -498,7 +530,8 @@ class TestMissingFiles:
         '--data-dir' should be required
         """
         result = subprocess.run(
-            ["doppel-describe", "--pkg_name", "argparse", "-l", "python"], stderr=subprocess.PIPE
+            ["doppel-describe", "--pkg_name", "argparse", "-l", "python"],
+            stderr=subprocess.PIPE,
         )
         error_text = result.stderr.decode("utf-8")
         assert bool(re.search('Missing option "--data-dir"', error_text))

--- a/integration_tests/python_tests/test_analyze.py
+++ b/integration_tests/python_tests/test_analyze.py
@@ -166,9 +166,7 @@ class TestBasicContract:
 
             assert len(class_interface.keys()) == 1
 
-            for method_name, method_interface in class_interface[
-                "public_methods"
-            ].items():
+            for method_name, method_interface in class_interface["public_methods"].items():
                 args = method_interface["args"]
                 assert isinstance(args, list)
                 assert len(method_interface.keys()) == 1
@@ -255,9 +253,7 @@ class TestClassStuff:
         for e in expected_methods:
             assert class_dict["ClassA"]["public_methods"].get(e, False)
 
-        assert len(class_dict["ClassA"]["public_methods"].keys()) == len(
-            expected_methods
-        )
+        assert len(class_dict["ClassA"]["public_methods"].keys()) == len(expected_methods)
 
     def test_inherited_class_public_methods_found(self, rundescribe):
         """
@@ -281,9 +277,7 @@ class TestClassStuff:
         for e in expected_methods:
             assert class_dict["ClassB"]["public_methods"].get(e, False)
 
-        assert len(class_dict["ClassB"]["public_methods"].keys()) == len(
-            expected_methods
-        )
+        assert len(class_dict["ClassB"]["public_methods"].keys()) == len(expected_methods)
 
     def test_classmethods_found(self, rundescribe):
         """
@@ -321,9 +315,9 @@ class TestClassStuff:
         Totally empty classes should still have their
         constructors documented
         """
-        assert list(
-            rundescribe["testpkguno"]["classes"]["ClassF"]["public_methods"].keys()
-        ) == ["~~CONSTRUCTOR~~"]
+        assert list(rundescribe["testpkguno"]["classes"]["ClassF"]["public_methods"].keys()) == [
+            "~~CONSTRUCTOR~~"
+        ]
         assert rundescribe["testpkguno"]["classes"]["ClassF"]["public_methods"][
             "~~CONSTRUCTOR~~"
         ] == {"args": []}
@@ -391,9 +385,7 @@ class TestPythonSpecific:
         result_json = rundescribe["pythonspecific"]
 
         assert set(result_json["functions"].keys()) == set(["some_function"])
-        assert set(result_json["classes"].keys()) == set(
-            ["SomeClass", "GreatClass", "MinWrapper"]
-        )
+        assert set(result_json["classes"].keys()) == set(["SomeClass", "GreatClass", "MinWrapper"])
 
     def test_inner_classes(self, rundescribe):
         """
@@ -403,12 +395,10 @@ class TestPythonSpecific:
         """
         result_json = rundescribe["pythonspecific"]
 
-        assert set(
-            result_json["classes"]["GreatClass"]["public_methods"].keys()
-        ) == set(["do_stuff", "LilGreatClass", "~~CONSTRUCTOR~~"])
-        lil_args = result_json["classes"]["GreatClass"]["public_methods"][
-            "LilGreatClass"
-        ]["args"]
+        assert set(result_json["classes"]["GreatClass"]["public_methods"].keys()) == set(
+            ["do_stuff", "LilGreatClass", "~~CONSTRUCTOR~~"]
+        )
+        lil_args = result_json["classes"]["GreatClass"]["public_methods"]["LilGreatClass"]["args"]
         assert set(lil_args) == set(["things", "stuff"])
 
     def test_builtin_func(self, rundescribe):
@@ -430,9 +420,7 @@ class TestPythonSpecific:
         """
         result_json = rundescribe["pythonspecific"]
 
-        assert result_json["classes"]["MinWrapper"]["public_methods"]["wrap_min"] == {
-            "args": []
-        }
+        assert result_json["classes"]["MinWrapper"]["public_methods"]["wrap_min"] == {"args": []}
 
 
 class TestWeirdImportStuff:
@@ -462,9 +450,7 @@ class TestWeirdImportStuff:
         """
         result_json = rundescribe["pythonspecific2"]
 
-        assert set(result_json["functions"].keys()) == set(
-            ["create_warning", "create_warm_things"]
-        )
+        assert set(result_json["functions"].keys()) == set(["create_warning", "create_warm_things"])
         # imports from other packages are included if you explicitly
         # wrap them in a def()
         assert "create_warm_things" in result_json["functions"]

--- a/tests/test_package_api.py
+++ b/tests/test_package_api.py
@@ -23,11 +23,15 @@ class TestPackageAPI(unittest.TestCase):
         self.assertEqual(pkg.name(), "boombap [python]")
         self.assertEqual(pkg.num_functions(), 1)
         self.assertEqual(pkg.function_names(), ["playback"])
-        self.assertEqual(pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}})
+        self.assertEqual(
+            pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}}
+        )
         self.assertEqual(pkg.num_classes(), 1)
         self.assertEqual(pkg.class_names(), ["LupeFiasco"])
         self.assertEqual(pkg.public_methods("LupeFiasco"), ["coast", "~~CONSTRUCTOR~~"])
-        self.assertEqual(pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"])
+        self.assertEqual(
+            pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"]
+        )
         self.assertEqual(pkg.public_method_args("LupeFiasco", "coast"), [])
 
     def test_from_json_r(self):
@@ -39,10 +43,18 @@ class TestPackageAPI(unittest.TestCase):
         self.assertEqual(pkg.name(), "boombap [r]")
         self.assertEqual(pkg.num_functions(), 1)
         self.assertEqual(pkg.function_names(), ["playback"])
-        self.assertEqual(pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}})
+        self.assertEqual(
+            pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}}
+        )
         self.assertEqual(pkg.num_classes(), 1)
         self.assertEqual(pkg.class_names(), ["LupeFiasco"])
-        self.assertEqual(pkg.public_methods("LupeFiasco"), ["coast", "words", "~~CONSTRUCTOR~~"])
-        self.assertEqual(pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"])
+        self.assertEqual(
+            pkg.public_methods("LupeFiasco"), ["coast", "words", "~~CONSTRUCTOR~~"]
+        )
+        self.assertEqual(
+            pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"]
+        )
         self.assertEqual(pkg.public_method_args("LupeFiasco", "coast"), [])
-        self.assertEqual(pkg.public_method_args("LupeFiasco", "words"), ["i_said", "i_never_said"])
+        self.assertEqual(
+            pkg.public_method_args("LupeFiasco", "words"), ["i_said", "i_never_said"]
+        )

--- a/tests/test_package_api.py
+++ b/tests/test_package_api.py
@@ -23,15 +23,11 @@ class TestPackageAPI(unittest.TestCase):
         self.assertEqual(pkg.name(), "boombap [python]")
         self.assertEqual(pkg.num_functions(), 1)
         self.assertEqual(pkg.function_names(), ["playback"])
-        self.assertEqual(
-            pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}}
-        )
+        self.assertEqual(pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}})
         self.assertEqual(pkg.num_classes(), 1)
         self.assertEqual(pkg.class_names(), ["LupeFiasco"])
         self.assertEqual(pkg.public_methods("LupeFiasco"), ["coast", "~~CONSTRUCTOR~~"])
-        self.assertEqual(
-            pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"]
-        )
+        self.assertEqual(pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"])
         self.assertEqual(pkg.public_method_args("LupeFiasco", "coast"), [])
 
     def test_from_json_r(self):
@@ -43,18 +39,10 @@ class TestPackageAPI(unittest.TestCase):
         self.assertEqual(pkg.name(), "boombap [r]")
         self.assertEqual(pkg.num_functions(), 1)
         self.assertEqual(pkg.function_names(), ["playback"])
-        self.assertEqual(
-            pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}}
-        )
+        self.assertEqual(pkg.functions_with_args(), {"playback": {"args": ["bpm", "bass"]}})
         self.assertEqual(pkg.num_classes(), 1)
         self.assertEqual(pkg.class_names(), ["LupeFiasco"])
-        self.assertEqual(
-            pkg.public_methods("LupeFiasco"), ["coast", "words", "~~CONSTRUCTOR~~"]
-        )
-        self.assertEqual(
-            pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"]
-        )
+        self.assertEqual(pkg.public_methods("LupeFiasco"), ["coast", "words", "~~CONSTRUCTOR~~"])
+        self.assertEqual(pkg.public_method_args("LupeFiasco", "~~CONSTRUCTOR~~"), ["kick", "push"])
         self.assertEqual(pkg.public_method_args("LupeFiasco", "coast"), [])
-        self.assertEqual(
-            pkg.public_method_args("LupeFiasco", "words"), ["i_said", "i_never_said"]
-        )
+        self.assertEqual(pkg.public_method_args("LupeFiasco", "words"), ["i_said", "i_never_said"])

--- a/tests/test_package_collection.py
+++ b/tests/test_package_collection.py
@@ -13,7 +13,10 @@ class TestPackageAPI(unittest.TestCase):
 
     def setUp(self):
         self.pkg_collection = PackageCollection(
-            packages=[PackageAPI.from_json(self.py_pkg_file), PackageAPI.from_json(self.r_pkg_file)]
+            packages=[
+                PackageAPI.from_json(self.py_pkg_file),
+                PackageAPI.from_json(self.r_pkg_file),
+            ]
         )
 
     def test_all_classes(self):
@@ -66,7 +69,9 @@ class TestPackageAPI(unittest.TestCase):
         """
         shared = self.pkg_collection.shared_methods_by_class()
         self.assertEqual(list(shared.keys()), ["LupeFiasco"])
-        self.assertEqual(sorted(shared["LupeFiasco"]), sorted(["~~CONSTRUCTOR~~", "coast"]))
+        self.assertEqual(
+            sorted(shared["LupeFiasco"]), sorted(["~~CONSTRUCTOR~~", "coast"])
+        )
 
     def test_same_names(self):
         """

--- a/tests/test_package_collection.py
+++ b/tests/test_package_collection.py
@@ -69,9 +69,7 @@ class TestPackageAPI(unittest.TestCase):
         """
         shared = self.pkg_collection.shared_methods_by_class()
         self.assertEqual(list(shared.keys()), ["LupeFiasco"])
-        self.assertEqual(
-            sorted(shared["LupeFiasco"]), sorted(["~~CONSTRUCTOR~~", "coast"])
-        )
+        self.assertEqual(sorted(shared["LupeFiasco"]), sorted(["~~CONSTRUCTOR~~", "coast"]))
 
     def test_same_names(self):
         """

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -31,7 +31,10 @@ PACKAGE_WITH_DIFFERENT_ARG_NUMBER["functions"]["playback"]["args"].append("other
 
 PACKAGE_WITH_DIFFERENT_ARGS = copy.deepcopy(BASE_PACKAGE)
 PACKAGE_WITH_DIFFERENT_ARGS["name"] = "pkg2"
-PACKAGE_WITH_DIFFERENT_ARGS["functions"]["playback"]["args"] = ["bass", "beats_per_minute"]
+PACKAGE_WITH_DIFFERENT_ARGS["functions"]["playback"]["args"] = [
+    "bass",
+    "beats_per_minute",
+]
 
 PACKAGE_WITH_DIFFERENT_ARG_ORDER = copy.deepcopy(BASE_PACKAGE)
 PACKAGE_WITH_DIFFERENT_ARG_ORDER["name"] = "pkg2"
@@ -50,28 +53,33 @@ BASE_PACKAGE_WITH_CLASSES["classes"] = {
 
 PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
 PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER["name"] = "pkg2"
-PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER["classes"]["WaleFolarin"]["public_methods"]["no_days_off"][
-    "args"
-].append("about_nothing")
+PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER["classes"]["WaleFolarin"]["public_methods"][
+    "no_days_off"
+]["args"].append("about_nothing")
 
 PACKAGE_WITH_DIFFERENT_PM_ARGS = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
 PACKAGE_WITH_DIFFERENT_PM_ARGS["name"] = "pkg3"
-PACKAGE_WITH_DIFFERENT_PM_ARGS["classes"]["WaleFolarin"]["public_methods"]["no_days_off"][
-    "args"
-] = ["days_to_take", "outchyea"]
+PACKAGE_WITH_DIFFERENT_PM_ARGS["classes"]["WaleFolarin"]["public_methods"][
+    "no_days_off"
+]["args"] = ["days_to_take", "outchyea"]
 
 PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
 PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER["name"] = "pkg4"
-PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER["classes"]["WaleFolarin"]["public_methods"]["no_days_off"][
-    "args"
-] = ["songs_to_record", "days_to_take"]
+PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER["classes"]["WaleFolarin"]["public_methods"][
+    "no_days_off"
+]["args"] = ["songs_to_record", "days_to_take"]
 
 # super different
 PACKAGE_SUPER_DIFFERENT = copy.deepcopy(BASE_PACKAGE)
 PACKAGE_SUPER_DIFFERENT["name"] = "pkg2"
 PACKAGE_SUPER_DIFFERENT["functions"]["playback"]["args"] = ["stuff", "things", "bass"]
 
-PACKAGE_EMPTY = {"name": "empty_pkg", "language": "python", "functions": {}, "classes": {}}
+PACKAGE_EMPTY = {
+    "name": "empty_pkg",
+    "language": "python",
+    "functions": {},
+    "classes": {},
+}
 PACKAGE_EMPTY2 = copy.deepcopy(PACKAGE_EMPTY)
 PACKAGE_EMPTY2["name"] = "pkg2"
 
@@ -83,7 +91,9 @@ for i in range(5):
 
     class_name = "class_" + str(i)
     PACKAGE_BEEFY["classes"][class_name] = {
-        "public_methods": {k: {"args": ["thing", "stuff", "ok"]} for k in ["get", "push", "delete"]}
+        "public_methods": {
+            k: {"args": ["thing", "stuff", "ok"]} for k in ["get", "push", "delete"]
+        }
     }
 
 PACKAGE_BEEFY2 = copy.deepcopy(PACKAGE_BEEFY)
@@ -95,7 +105,10 @@ PACKAGE_DIFFERENT_METHODS_1 = {
     "functions": {},
     "classes": {
         "SomeClass": {
-            "public_methods": {"~~CONSTRUCTOR~~": {"args": []}, "write_py": {"args": ["x", "y"]}}
+            "public_methods": {
+                "~~CONSTRUCTOR~~": {"args": []},
+                "write_py": {"args": ["x", "y"]},
+            }
         }
     },
 }
@@ -115,7 +128,10 @@ class TestSimpleReporter(unittest.TestCase):
         number of keyword arguments.
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_NUMBER)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE),
+                PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_NUMBER),
+            ],
             errors_allowed=100,
         )
         reporter._check_function_args()
@@ -156,7 +172,10 @@ class TestSimpleReporter(unittest.TestCase):
         both packages but they are in different orders'
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_ORDER)],
+            pkgs=[
+                PackageAPI(BASE_PACKAGE),
+                PackageAPI(PACKAGE_WITH_DIFFERENT_ARG_ORDER),
+            ],
             errors_allowed=100,
         )
         reporter._check_function_args()
@@ -176,14 +195,16 @@ class TestSimpleReporter(unittest.TestCase):
         and different order.
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_SUPER_DIFFERENT)], errors_allowed=100
+            pkgs=[PackageAPI(BASE_PACKAGE), PackageAPI(PACKAGE_SUPER_DIFFERENT)],
+            errors_allowed=100,
         )
         reporter._check_function_args()
         errors = reporter.errors
         self.assertTrue(len(errors) == 3)
         self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
         expected_message = (
-            "Function 'playback()' exists in all packages but " "with differing number of arguments"
+            "Function 'playback()' exists in all packages but "
+            "with differing number of arguments"
         )
         self.assertTrue(errors[0].msg.startswith(expected_message))
 
@@ -276,7 +297,10 @@ class TestSimpleReporter(unittest.TestCase):
         but with different methods.
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(PACKAGE_DIFFERENT_METHODS_1), PackageAPI(PACKAGE_DIFFERENT_METHODS_2)],
+            pkgs=[
+                PackageAPI(PACKAGE_DIFFERENT_METHODS_1),
+                PackageAPI(PACKAGE_DIFFERENT_METHODS_2),
+            ],
             errors_allowed=2,
         )
         reporter._check_class_public_methods()
@@ -295,7 +319,8 @@ class TestSimpleReporter(unittest.TestCase):
         are totally empty.
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(PACKAGE_EMPTY), PackageAPI(PACKAGE_EMPTY2)], errors_allowed=0
+            pkgs=[PackageAPI(PACKAGE_EMPTY), PackageAPI(PACKAGE_EMPTY2)],
+            errors_allowed=0,
         )
         reporter._check_function_args()
         self.assertTrue(reporter.errors == [])
@@ -326,7 +351,8 @@ class TestSimpleReporter(unittest.TestCase):
         on shared classes and functions)
         """
         reporter = SimpleReporter(
-            pkgs=[PackageAPI(PACKAGE_BEEFY), PackageAPI(PACKAGE_BEEFY2)], errors_allowed=100
+            pkgs=[PackageAPI(PACKAGE_BEEFY), PackageAPI(PACKAGE_BEEFY2)],
+            errors_allowed=100,
         )
 
         # SimpleReporter has a sys.exit() in it. Mock that out
@@ -344,7 +370,9 @@ class TestSimpleReporter(unittest.TestCase):
         SimpleReporter should not return any errors if you
         only use a single package
         """
-        reporter = SimpleReporter(pkgs=[PackageAPI(BASE_PACKAGE_WITH_CLASSES)], errors_allowed=0)
+        reporter = SimpleReporter(
+            pkgs=[PackageAPI(BASE_PACKAGE_WITH_CLASSES)], errors_allowed=0
+        )
 
         # SimpleReporter has a sys.exit() in it. Mock that out
         def f():

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -53,21 +53,21 @@ BASE_PACKAGE_WITH_CLASSES["classes"] = {
 
 PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
 PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER["name"] = "pkg2"
-PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER["classes"]["WaleFolarin"]["public_methods"][
-    "no_days_off"
-]["args"].append("about_nothing")
+PACKAGE_WITH_DIFFERENT_PM_ARG_NUMBER["classes"]["WaleFolarin"]["public_methods"]["no_days_off"][
+    "args"
+].append("about_nothing")
 
 PACKAGE_WITH_DIFFERENT_PM_ARGS = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
 PACKAGE_WITH_DIFFERENT_PM_ARGS["name"] = "pkg3"
-PACKAGE_WITH_DIFFERENT_PM_ARGS["classes"]["WaleFolarin"]["public_methods"][
-    "no_days_off"
-]["args"] = ["days_to_take", "outchyea"]
+PACKAGE_WITH_DIFFERENT_PM_ARGS["classes"]["WaleFolarin"]["public_methods"]["no_days_off"][
+    "args"
+] = ["days_to_take", "outchyea"]
 
 PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER = copy.deepcopy(BASE_PACKAGE_WITH_CLASSES)
 PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER["name"] = "pkg4"
-PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER["classes"]["WaleFolarin"]["public_methods"][
-    "no_days_off"
-]["args"] = ["songs_to_record", "days_to_take"]
+PACKAGE_WITH_DIFFERENT_PM_ARG_ORDER["classes"]["WaleFolarin"]["public_methods"]["no_days_off"][
+    "args"
+] = ["songs_to_record", "days_to_take"]
 
 # super different
 PACKAGE_SUPER_DIFFERENT = copy.deepcopy(BASE_PACKAGE)
@@ -91,9 +91,7 @@ for i in range(5):
 
     class_name = "class_" + str(i)
     PACKAGE_BEEFY["classes"][class_name] = {
-        "public_methods": {
-            k: {"args": ["thing", "stuff", "ok"]} for k in ["get", "push", "delete"]
-        }
+        "public_methods": {k: {"args": ["thing", "stuff", "ok"]} for k in ["get", "push", "delete"]}
     }
 
 PACKAGE_BEEFY2 = copy.deepcopy(PACKAGE_BEEFY)
@@ -203,8 +201,7 @@ class TestSimpleReporter(unittest.TestCase):
         self.assertTrue(len(errors) == 3)
         self.assertTrue(all([isinstance(x, DoppelTestError) for x in errors]))
         expected_message = (
-            "Function 'playback()' exists in all packages but "
-            "with differing number of arguments"
+            "Function 'playback()' exists in all packages but " "with differing number of arguments"
         )
         self.assertTrue(errors[0].msg.startswith(expected_message))
 
@@ -370,9 +367,7 @@ class TestSimpleReporter(unittest.TestCase):
         SimpleReporter should not return any errors if you
         only use a single package
         """
-        reporter = SimpleReporter(
-            pkgs=[PackageAPI(BASE_PACKAGE_WITH_CLASSES)], errors_allowed=0
-        )
+        reporter = SimpleReporter(pkgs=[PackageAPI(BASE_PACKAGE_WITH_CLASSES)], errors_allowed=0)
 
         # SimpleReporter has a sys.exit() in it. Mock that out
         def f():


### PR DESCRIPTION
Fixes #204.

This small PR was made to change `{ }.format(a)` to f-strings, `f"( {a} )"`.