### PR TITLE
move Python version floor to v3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,22 @@ jobs:
         include:
           - os: ubuntu-latest
             task: lint
-            python_version: 3.11
+            python_version: '3.11'
           - os: ubuntu-latest
             task: test
-            python_version: 3.8
+            python_version: '3.8'
           - os: ubuntu-latest
             task: test
-            python_version: 3.9
+            python_version: '3.9'
           - os: ubuntu-latest
             task: test
-            python_version: 3.10
+            python_version: '3.10'
           # - os: macOS-latest
           #   task: test
           #   python_version: 3.8
           - os: windows-latest
             task: test
-            python_version: 3.10
+            python_version: '3.10'
     steps:
       - name: Prevent conversion of line endings on Windows
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,22 @@ jobs:
         include:
           - os: ubuntu-latest
             task: lint
-            python_version: 3.8
-          - os: ubuntu-latest
-            task: test
-            python_version: 3.6
-          - os: ubuntu-latest
-            task: test
-            python_version: 3.7
+            python_version: 3.11
           - os: ubuntu-latest
             task: test
             python_version: 3.8
+          - os: ubuntu-latest
+            task: test
+            python_version: 3.9
+          - os: ubuntu-latest
+            task: test
+            python_version: 3.10
           # - os: macOS-latest
           #   task: test
           #   python_version: 3.8
           - os: windows-latest
             task: test
-            python_version: 3.8
+            python_version: 3.10
     steps:
       - name: Prevent conversion of line endings on Windows
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-and-publish:
     name: Build and publish doppel-cli to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-and-publish:
     name: Build and publish doppel-cli to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     maintainer="James Lamb",
     maintainer_email="jaylamb20@gmail.com",
     install_requires=runtime_deps,
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     extras_require={
         "docs": documentation_deps,
         "testing": testing_deps,
@@ -53,9 +53,10 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Testing",
     ],
 )


### PR DESCRIPTION
Updates minimum Python version to `>=3.8`.

Updates all CI jobs to more recent versions of Python, to match.