### PR TITLE
[ci] remove separate 'pycodestyle' step

### DIFF
--- a/.ci/lint-py.sh
+++ b/.ci/lint-py.sh
@@ -62,18 +62,6 @@ echo ""
 
     echo ""
     echo "###############"
-    echo "# pycodestyle #"
-    echo "###############"
-    echo ""
-    pycodestyle \
-        --show-source \
-        --max-line-length ${MAX_LINE_LENGTH} \
-        --count \
-        ${SOURCE_DIR} \
-    || exit -1
-
-    echo ""
-    echo "###############"
     echo "#    mypy     #"
     echo "###############"
     echo ""

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -26,7 +26,6 @@ if [[ $TASK == "lint" ]]; then
             black \
             flake8 \
             mypy \
-            pycodestyle \
             pylint
     make lint
     #Rscript ${CI_TOOLS}/lint-r-code.R $(pwd)


### PR DESCRIPTION
This project already runs `flake8`.

https://github.com/jameslamb/doppel-cli/blob/0421564357ddad1bac651826e95c21ab5659ab82/.ci/lint-py.sh#L37-L40

which enforces all of the `pycodestyle` checks

https://flake8.pycqa.org/en/2.6.0/

so installing `pycodestyle` separately and running it separately are unnecessary.